### PR TITLE
Generate optimized binary

### DIFF
--- a/build
+++ b/build
@@ -31,7 +31,8 @@ else
   VERSION=`grep VER sdr_ui.h|awk 'FNR==1{print $4}'|sed -e 's/"//g'`
   echo "compiling $F version $VERSION in $WORKING_DIRECTORY"
 fi
-gcc -g -o $F \
+echo "Building debug binary"
+gcc -g -o $F-debug \
 	 vfo.c si570.c sbitx_sound.c fft_filter.c  sbitx_gtk.c sbitx_utils.c \
     i2cbb.c si5351v2.c ini.c hamlib.c queue.c modems.c logbook.c \
 		modem_cw.c settings_ui.c \
@@ -39,4 +40,14 @@ gcc -g -o $F \
 		ft8_lib/libft8.a  \
 	-lwiringPi -lasound -lm -lfftw3 -lfftw3f -pthread -lncurses -lsqlite3\
 	`pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
+echo "Building opimized binary"
+gcc -o $F -O3 -flto=auto -mtune=native  \
+	 vfo.c si570.c sbitx_sound.c fft_filter.c  sbitx_gtk.c sbitx_utils.c \
+    i2cbb.c si5351v2.c ini.c hamlib.c queue.c modems.c logbook.c \
+		modem_cw.c settings_ui.c \
+		telnet.c macros.c modem_ft8.c remote.c mongoose.c webserver.c $F.c  \
+		ft8_lib/libft8.a  \
+	-lwiringPi -lasound -lm -lfftw3 -lfftw3f -pthread -lncurses -lsqlite3\
+	`pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
+strip $F
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"


### PR DESCRIPTION
Generate and use an optimized binary, while also building a debug binary for testing.  

Saw about 1% less cpu usage in a quick test.