### PR TITLE
Allow adjustment of bfo during runtime

### DIFF
--- a/src/docs/commands.txt
+++ b/src/docs/commands.txt
@@ -31,6 +31,11 @@ These are text commands that can be entered from the keyboard
 \txpitch [in Hz]
 	Sets the tone of transmit tone of the CW. 
 	Ex: \txpitch 700
+\bfo [offset in HZ]
+    Allows adjustment of BFO during runtime; pass a value in +/- HZ
+	Passing a value of 0 will reset to default/no offset
+	An offset of +/- 3000 is usually enough to move birdies out of the passband
+	Value is not saved and always 0 on a fresh launch
 10M	
 12M
 15M

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -73,6 +73,7 @@ fftw_complex *fft_in;			// holds the incoming samples in time domain (for rx as 
 fftw_complex *fft_m;			// holds previous samples for overlap and discard convolution 
 fftw_plan plan_fwd, plan_tx;
 int bfo_freq = 40035000;
+int bfo_freq_runtime_offset = 0; //Runtime bfo offset
 int freq_hdr = -1;
 
 static double volume 	= 100.0;
@@ -153,15 +154,24 @@ struct Queue qremote;
 
 void radio_tune_to(u_int32_t f){
 	if (rx_list->mode == MODE_CW)
-  	si5351bx_setfreq(2, f + bfo_freq - 24000 + TUNING_SHIFT - rx_pitch);
+  	si5351bx_setfreq(2, f + bfo_freq + bfo_freq_runtime_offset - 24000 + TUNING_SHIFT - rx_pitch);
 	else if (rx_list->mode == MODE_CWR)
-  	si5351bx_setfreq(2, f + bfo_freq - 24000 + TUNING_SHIFT + rx_pitch);
+  	si5351bx_setfreq(2, f + bfo_freq + bfo_freq_runtime_offset- 24000 + TUNING_SHIFT + rx_pitch);
 	else
-  	si5351bx_setfreq(2, f + bfo_freq - 24000 + TUNING_SHIFT);
+  	si5351bx_setfreq(2, f + bfo_freq + bfo_freq_runtime_offset - 24000 + TUNING_SHIFT);
 
 //  printf("Setting radio rx_pitch %d\n", rx_pitch);
 }
-
+long set_bfo_offset(int offset, long cur_freq) {
+	bfo_freq_runtime_offset += offset;
+	resetup_oscillators();
+	radio_tune_to(cur_freq);
+	return bfo_freq + bfo_freq_runtime_offset;
+	
+}
+int get_bfo_offset() {
+	return bfo_freq_runtime_offset;
+}
 void fft_init(){
 	// int mem_needed;
 
@@ -1132,14 +1142,18 @@ void setup_oscillators(){
   delay(200);
   si5351bx_init();
   delay(200);
-  si5351bx_setfreq(1, bfo_freq);
-
-  delay(200);
-  si5351bx_setfreq(1, bfo_freq);
+  si5351bx_setfreq(1, bfo_freq + bfo_freq_runtime_offset);
+  //TODO:  Seems to not be needed, but worth testing before release - n1qm
+  //delay(200);
+  //si5351bx_setfreq(1, bfo_freq + bfo_freq_runtime_offset);
 
   si5351_reset();
 }
-
+void resetup_oscillators(){
+  //re-initialize the SI5351
+  si5351bx_setfreq(1, bfo_freq + bfo_freq_runtime_offset);
+  si5351_reset();
+}
 static int hw_init_index = 0;
 static int hw_settings_handler(void* user, const char* section, 
             const char* name, const char* value)

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -5147,6 +5147,21 @@ void cmd_exec(char *cmd){
 		sprintf(buff, "txpitch is set to %d Hz\n", get_cw_tx_pitch());
 		write_console(FONT_LOG, buff);
 	}
+	else if (!strcmp(exec,"bfo")) {
+		//Change runtime bfo to get rid of birdies in passband
+		long freq = atol(args);
+		if (!strlen(args)) {
+			write_console(FONT_LOG, "Usage:\n\\bfo xxxxx (in Hz to adjust bfo, 0 to reset)\n");
+		}
+		//Clear offset if requested freq = 0
+		if (freq == 0){
+			freq -= get_bfo_offset();
+		}
+		long result = set_bfo_offset(freq, atol(get_field("r1:freq")->value));
+		char output[500];
+		sprintf(output,"BFO %d offset = %d\n", get_bfo_offset(), result);
+		write_console(FONT_LOG, output);
+	}
 /*	else if (!strcmp(exec, "PITCH")){
 		struct field *f = get_field_by_label(exec);
 		field_set("PITCH", args);

--- a/src/sdr.h
+++ b/src/sdr.h
@@ -128,8 +128,9 @@ struct filter *filter_new(int input_length, int impulse_length);
 int filter_tune(struct filter *f, float const low,float const high,float const kaiser_beta);
 int make_hann_window(float *window, int max_count);
 void filter_print(struct filter *f);
-
-
+long set_bfo_offset(int offset,long freq);
+void resetup_oscillators();
+int get_bfo_offset();
 // Complex norm (sum of squares of real and imaginary parts)
 static inline float const cnrmf(const complex float x){
   return crealf(x)*crealf(x) + cimagf(x) * cimagf(x);


### PR DESCRIPTION
Live adjustment of BFO to allow allow moving noise/birdies out of passband.  Can be adjusted by +/- Hz, sending a 0 resets the offset.

Also made a change to https://github.com/drexjj/sbitx/pull/29/files#diff-c19db215691396ca00cf199b1df61036ca1060abbf63389e1869e949fad175bfR1145 that didn't affect my radio, but worth testing.