### PR TITLE
S meter fixes

### DIFF
--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -67,7 +67,7 @@ char wisdom_file[] = "sbitx_wisdom.wis";
 
 #define NOISE_ALPHA 0.9  // Smoothing factor for DSP noise estimation 0.0->1.0 >responsive/>stable -> >responsive/>stable
 #define SIGNAL_ALPHA 0.90 // Smoothing factor for DSP observed power spectrum estimation 0.9->0.99 >responsive/>stable -> >responsive/>stable
-#define SCALING_TRIM 200.0 // Use this to tune your meter response 200.0 worked at 52 IF and my inverted L
+#define SCALING_TRIM 2.7 // Use this to tune your meter response 
 
 fftw_complex *fft_out;		// holds the incoming samples in freq domain (for rx as well as tx)
 fftw_complex *fft_in;			// holds the incoming samples in time domain (for rx as well as tx) 
@@ -332,10 +332,10 @@ int calculate_s_meter(struct rx *r, double rx_gain) {
     signal_strength /= (MAX_BINS / 2);
 
     // Logarithmic scaling based on rx_gain setting in percentage [0-100]
-    double gain_scaling_factor = log10(rx_gain / 100.0 + 1.0); 
+    double gain_scaling_factor = log10(rx_gain / 100.0 + 1.0)* 60.0; 
 
     // Convert to pseudo dB
-    double reference_power = 1e-4; // 0.1 mW
+    double reference_power = 1e-5; // 1e-5 10 µW
     double signal_power = signal_strength * signal_strength * reference_power;
     double s_meter_db = 10 * log10(signal_power / reference_power); // pseudo dB
     

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -67,7 +67,7 @@ char wisdom_file[] = "sbitx_wisdom.wis";
 
 #define NOISE_ALPHA 0.9  // Smoothing factor for DSP noise estimation 0.0->1.0 >responsive/>stable -> >responsive/>stable
 #define SIGNAL_ALPHA 0.90 // Smoothing factor for DSP observed power spectrum estimation 0.9->0.99 >responsive/>stable -> >responsive/>stable
-#define SCALING_TRIM 200.0 // Use this to tune your meter response 2.7 worked at 51% and my inverted L
+#define SCALING_TRIM 200.0 // Use this to tune your meter response 200.0 worked at 52 IF and my inverted L
 
 fftw_complex *fft_out;		// holds the incoming samples in freq domain (for rx as well as tx)
 fftw_complex *fft_in;			// holds the incoming samples in time domain (for rx as well as tx) 

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -67,7 +67,7 @@ char wisdom_file[] = "sbitx_wisdom.wis";
 
 #define NOISE_ALPHA 0.9  // Smoothing factor for DSP noise estimation 0.0->1.0 >responsive/>stable -> >responsive/>stable
 #define SIGNAL_ALPHA 0.90 // Smoothing factor for DSP observed power spectrum estimation 0.9->0.99 >responsive/>stable -> >responsive/>stable
-#define SCALING_TRIM 2.7 // Use this to tune your meter response 2.7 worked at 51% and my inverted L
+#define SCALING_TRIM 200.0 // Use this to tune your meter response 2.7 worked at 51% and my inverted L
 
 fftw_complex *fft_out;		// holds the incoming samples in freq domain (for rx as well as tx)
 fftw_complex *fft_in;			// holds the incoming samples in time domain (for rx as well as tx) 
@@ -105,6 +105,10 @@ int notch_enabled = 0;//notch filter W2JON
 double notch_freq = 0; // Notch frequency in Hz W2JON
 double notch_bandwidth = 0; // Notch bandwidth in Hz W2JON
 
+int get_rx_gain(void) {
+	//printf("rx_gain %d\n", rx_gain);
+    return rx_gain;
+}
 extern void check_r1_volume();//Volume control normalization W2JON
 static int rx_vol;
 

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -47,7 +47,8 @@ The initial sync between the gui values, the core radio values, settings, et al 
 #include "para_eq.h"
 #include "eq_ui.h"
 
-extern int calculate_s_meter(struct rx *r);
+extern int get_rx_gain(void);
+extern int calculate_s_meter(struct rx *r, double rx_gain);
 extern struct rx *rx_list; 
 
 
@@ -2016,8 +2017,14 @@ if (!strcmp(field_str("SMETEROPT"), "ON")) {
 	int s_meter_value = 0;
 	struct rx *current_rx = rx_list;
 
-	s_meter_value = calculate_s_meter(current_rx); // we calculate the s-meter value (in sbitx.c)
+    // Retrieve the rx_gain value from sbitx.c using the getter function
+    double rx_gain = (double)get_rx_gain();
+	//printf("RX_GAIN %d\n", rx_gain);
 
+    // Pass the rx_gain along with the rx pointer
+    s_meter_value = calculate_s_meter(current_rx, rx_gain);
+
+	
 	// Lets separate the S-meter value into s-units and additional dB
 	int s_units = s_meter_value / 100;
 	int additional_db = s_meter_value % 100;

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -2502,9 +2502,17 @@ if (!strcmp(field_str("MENU"), "ON")) { // W2JON
 			field_move("RX", 360, y1, 95, 45);
 			break;
 		case MODE_DIGITAL:  // W9JES
-			field_move("CONSOLE", 5, y1, 350, y2-y1-55);
-			field_move("SPECTRUM", 360, y1, x2-365, 70);
-			field_move("WATERFALL", 360, y1+70, x2-365, y2-y1-125);
+			// N1QM
+			field_move("SPECT", screen_width -95, screen_height-47, 45, 45);
+			if (!strcmp(field_str("SPECT"), "FULL")) {
+				field_move("CONSOLE", 1000, -1000, 350, y2-y1-55);
+				field_move("SPECTRUM", 5, y1, x2-7, 70);
+				field_move("WATERFALL", 5, y1+70, x2-7, y2-y1-125);
+			}else{
+				field_move("CONSOLE", 5, y1, 350, y2-y1-55);
+				field_move("SPECTRUM", 360, y1, x2-365, 70);
+				field_move("WATERFALL", 360, y1+70, x2-365, y2-y1-125);
+			}
 			y1 = y2 -50;
 			field_move("MIC", 5, y1, 45, 45);
 			field_move("LOW", 60, y1, 95, 45);

--- a/src/sdr.h
+++ b/src/sdr.h
@@ -259,3 +259,6 @@ FILE *wav_start_writing(const char* path);
 #define MULTICAST_ADDR "224.0.0.1"
 #define MULTICAST_PORT 5005
 #define MULTICAST_MAX_BUFFER_SIZE 1024
+
+// S-Meter
+int get_rx_gain(void);


### PR DESCRIPTION
Changed the way that the rx_gain value is shared between sbitx.c and sbitx_gtk.c Because rx_gain is a static int it cannot be shared directly outside of sbitx.c so I put in a getter function int get_rx_gain(void); to retrieve the value and ship it over to the display function.
Also adjusted the SCALING_TRIM to get the s-meter close to local observations on another rig.