### PR TITLE
tx monitor function for headphones

### DIFF
--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -105,6 +105,7 @@ int notch_enabled = 0;//notch filter W2JON
 double notch_freq = 0; // Notch frequency in Hz W2JON
 double notch_bandwidth = 0; // Notch bandwidth in Hz W2JON
 int compression_control_level; // Audio Compression level W2JON
+int txmon_control_level; // TX Monitor level W2JON
 int get_rx_gain(void) {
 	//printf("rx_gain %d\n", rx_gain);
     return rx_gain;
@@ -1089,15 +1090,23 @@ if (in_tx && (r->mode != MODE_DIGITAL && r->mode != MODE_FT8 && r->mode != MODE_
 				i_sample = voice_clip_level;
 		}
 
-		//don't echo the voice modes
+		// Don't echo the voice modes
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM 
-			|| r->mode == MODE_NBFM)
-			output_speaker[j] = 0;
-		else
-			output_speaker[j] = i_sample * sidetone;
-	  	q_sample = 0;
+ 		   || r->mode == MODE_NBFM) {
+ 		   // Unless of course you want to use the txmon control
+		    if (txmon_control_level >= 1 && txmon_control_level <= 10) {	
+ 		       output_speaker[j] = i_sample * txmon_control_level * 1000000000.0;      
+	    } else {
+ 		       output_speaker[j] = 0;
+  		  }
+   		 q_sample = 0;
+		} else {
+   		// If not in voice modes, use the sidetone
+ 		   output_speaker[j] = i_sample * sidetone;
+ 		   q_sample = 0;
+		}
 
-	  	j++;
+		j++;
 
 	  	__real__ fft_m[m] = i_sample;
 	  	__imag__ fft_m[m] = q_sample;

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -493,6 +493,7 @@ int do_eqb(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_eq_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_notch_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_comp_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
+int do_txmon_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_dsp_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_bfo_offset(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 
@@ -674,6 +675,10 @@ struct field main_controls[] = {
   // EQ TX Audio Setting Controls
 	{"#eq_sliders", do_toggle_option, 1000, -1000, 40, 40, "EQSET", 40, "", FIELD_BUTTON, FONT_FIELD_VALUE,
 		"", 0,0,0,0},
+
+  // TX Audio Monitor 
+	{ "#tx_monitor", do_txmon_edit, 1000, -1000, 40, 40, "TXMON", 40, "0", FIELD_NUMBER, FONT_FIELD_VALUE, 
+    	"", 0, 10, 1, 0},		
 
   // VFO Lock ON/OFF
    	{ "#vfo_lock", do_toggle_option, 1000, -1000, 40, 40, "VFOLK", 40, "OFF", FIELD_TOGGLE, FONT_FIELD_VALUE,
@@ -2447,20 +2452,21 @@ void menu_display(int show) {
 		// NEW LAYOUT @ 3.2
         // Move each control to the appropriate position
 
-	  field_move("SET",5,screen_height - 140 ,45 ,45);  // w9jes
+	field_move("SET",5,screen_height - 140 ,45 ,45);  // w9jes
     field_move("EQSET",130,screen_height - 90 ,95 ,45);
-    field_move("TXEQ", 130, screen_height - 140, 95, 45);
-	  field_move("NOTCH", 240, screen_height - 140, 95, 45);
+    field_move("TXEQ", 130, screen_height - 140, 45, 45);
+	field_move("TXMON", 180, screen_height - 140, 45, 45);
+	field_move("NOTCH", 240, screen_height - 140, 95, 45);
     field_move("NFREQ", 240, screen_height - 90, 45, 45);
     field_move("BNDWTH", 290, screen_height - 90, 45, 45);
     field_move("COMP",  350, screen_height - 140, 95, 45);
-		field_move("ANR", 460, screen_height - 140, 95, 45); 
-		field_move("DSP", 350, screen_height - 90, 95, 45); 
-		//field_move("DSP", 350, screen_height - 90, 45, 45); 
-		//field_move("THSHLD", 400, screen_height - 90, 45, 45);
-        field_move("BFO", 460, screen_height - 90 ,45 ,45);
-		field_move("VFOLK", 510, screen_height - 90 ,45 ,45);
-		if (!strcmp(field_str("QROOPT"), "ON")) {
+	field_move("ANR", 460, screen_height - 140, 95, 45); 
+	field_move("DSP", 350, screen_height - 90, 95, 45); 
+	//field_move("DSP", 350, screen_height - 90, 45, 45); 
+	//field_move("THSHLD", 400, screen_height - 90, 45, 45);
+    field_move("BFO", 460, screen_height - 90 ,45 ,45);
+	field_move("VFOLK", 510, screen_height - 90 ,45 ,45);
+	if (!strcmp(field_str("QROOPT"), "ON")) {
 		field_move("QRO", 680,screen_height - 140 ,95 ,45);
 		}
     field_move("TUNE", 570, screen_height - 140 ,95 ,45); 
@@ -3779,14 +3785,15 @@ int do_comp_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c) 
     const char *compression_control_field = field_str("COMP");
     int compression_control_level_value = atoi(compression_control_field);
    	compression_control_level = compression_control_level_value;	
- //  if (compression_control_level_value >= 1) {
-//	   comp_enabled = 1;
- //  } else {
-//	   comp_enabled = 0;
- // }
     return 0;
 }
 
+int do_txmon_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
+    const char *txmon_control_field = field_str("TXMON");
+    int txmon_control_level_value = atoi(txmon_control_field);
+   	txmon_control_level = txmon_control_level_value;	
+    return 0;
+}
 
 int do_dsp_edit(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
     //Fix a compiler warning - n1qm

--- a/src/sound.h
+++ b/src/sound.h
@@ -51,3 +51,6 @@ double scaleNoiseThreshold(int control);
 // Aduio Compression tool
 extern int compression_control_level;
 void apply_fixed_compression(float *input, int num_samples, int compression_control_value);
+
+// TX Monitor tool
+extern int txmon_control_level;


### PR DESCRIPTION
Here we have the addition of a TX monitor tool which can be used to monitor the current audio chain settings. 

There are two points to note: 
1. Only use a headset or there will be feedback from the internal mic. 
2. The apparent process noise in the cans seems local and not transmitted over the air. 

All audio settings play off one another so misconfiguration will result in poor-sounding audio.
Experiment, experiment, experiment...
