### PR TITLE
default adjust of mic gain to 30 (50max)

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -586,8 +586,8 @@ struct field main_controls[] = {
 /* end of common controls */
 
 	//tx 
-	{ "tx_gain", NULL, 550, -350, 50, 50, "MIC", 40, "50", FIELD_NUMBER, FONT_FIELD_VALUE, 
-		"", 0, 100, 1, VOICE_CONTROL},
+	{ "tx_gain", NULL, 550, -350, 50, 50, "MIC", 40, "30", FIELD_NUMBER, FONT_FIELD_VALUE, 
+		"", 0, 50, 1, VOICE_CONTROL},
 
 	//{ "tx_compress", NULL, 600, -350, 50, 50, "COMP", 40, "0", FIELD_NUMBER, FONT_FIELD_VALUE, 
 	//	"ON/OFF", 0,100,10, VOICE_CONTROL},


### PR DESCRIPTION
There was a troublesome quirk that needed to be addressed. the mic gain gets blown out over 50 so I adjusted the tx_gain to max out at 50 and default to 30.. seems to have mellowed out the issue 