### PR TITLE
Updated notch filter to activate on CW/CWR also remove the indicator from digi mode panafall

### DIFF
--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -839,9 +839,9 @@ void rx_linear(int32_t *input_rx, int32_t *input_mic,
 		if (notch_enabled) {
 			int notch_center_bin, notch_bin_range;
 			
-			if (r->mode == MODE_USB) {
+			if (r->mode == MODE_USB || r->mode == MODE_CW) {
 				notch_center_bin = (int)(notch_freq / (sampling_rate / MAX_BINS));
-			} else if (r->mode == MODE_LSB) {
+			} else if (r->mode == MODE_LSB || r->mode == MODE_CWR) {
 				notch_center_bin = MAX_BINS - (int)(notch_freq / (sampling_rate / MAX_BINS));
 			}
 			notch_bin_range = (int)(notch_bandwidth / (sampling_rate / MAX_BINS));

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -1920,10 +1920,10 @@ void draw_spectrum(struct field *f_spectrum, cairo_t *gfx){
 	int center_x = f_spectrum->x + (f_spectrum->width / 2);
 
 	if (notch_enabled) {
-		if (!strcmp(mode_f->value, "CW") || !strcmp(mode_f->value, "CWR") || !strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "LSB") || !strcmp(mode_f->value, "DIGI")) {
+		if (!strcmp(mode_f->value, "CW") || !strcmp(mode_f->value, "CWR") || !strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "LSB")) {
 			// Calculate notch filter position and width based on mode
 			//Added digi to modes which can show the notch indicator - n1qm
-			if (!strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "CW") || !strcmp(mode_f->value, "DIGI")) {
+			if (!strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "CW")) {
 				// For USB and CW mode
 				notch_start = center_x + 
 							((f_spectrum->width * (notch_freq - notch_bandwidth / 2)) / (span * 1000));


### PR DESCRIPTION
The initial thought was that the CW op would use the BW settings to blank out the region where they wanted to work. 
I can understand the argument to have a notch available in that window to clear pesky QRM but it wasn't optional until now. 
