### PR TITLE
Show more useful values for the output power (#172)

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -6815,7 +6815,6 @@ void do_control_action(char *cmd)
 	if (tune_on_invoked)
 	{
 		time_t current_time = time(NULL);
-
 		// Check if the tune duration has elapsed
 		if (difftime(current_time, tune_on_start_time) >= tune_duration) 
 		{


### PR DESCRIPTION
* v4.3 (#159)

* Reverted unintended waterfall changes

* Fixed bug with waterfall on low resolution screens.  Caused by unintended merge.

* waterfall update

* Added Framework for Waterfall speed, and spectrum updates.  More to follow!

* BETA of Spectrum/waterfall mods

* Added Adjustable Spectrum Size, Inverted Speed control, Limited gain, Tweaked speed values

* Capped Scope Average at 16

* FIXED FT8 by limited averaging to 15, limited scope size to 120 to fix crash on smaller screens, Fixed Notch Filter bar.

* Fixed typo causing set button to disappear under certain circumstances

* Fixed crashing caused by scope size.

* Update to change band settings (Gain, Drive) via hamlib.

* Fixed EPTT button location

* Fixed focus contention between Band and Frequency

* Fixed Spectrum drag frequency change

* Fixed Tune power

* Rearranged button layout

Moved Tune button to main controls
Moved Web button to menu 1
Aligned and organized buttons by function in menu 1 and 2

* Fixed REC button

* added tune duration

* added field set to toggle tune off

* Fixed timing and controls for tune mode

* fix tune off cancellation

* Added tune power save/recall to user settings

* Update sbitx_gtk.c

* fix tune off function

* Add Lars html changes

* fix eptt label and control in html

* merge cw fixes from kb2ml (#157)

* Update modem_cw.c 

changes to cw_tx_get_sample, trying to improve CW straight key performance

* Update sbitx.c

- streamlined the transmit-receive switch as much as possible with the goal of contributing to CW straight key performance
- eliminate switching LPFs in and out during TR switching
- eliminated some switching delays

* Update sbitx_gtk.c for straight key performance

modified ui_tick() to increase calls to modem_poll when in MODE_CW or CWR.

* Update modem_cw.c

ensuring changes match my local baseline

---------



* Update ver string to 4.3

* Update default_settings.ini

* Adjusted menu settings for bottom padding. Added Scope Intensity control

* Adjusted menu padding, Added Scope Intensity setting control

* Update sbitx_gtk.c

* Update README.md

* v4.3


---------







* Patch for Tune toggle (#160)

* v4.3 patch

* Add files via upload

* Create QSSVTV

* Add files via upload

* Delete sBitx v4.3 commands.pdf

* Show readable values for the output power

---------