### PR TITLE
improve cw decoder in modem_cw.c

### DIFF
--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -905,40 +905,25 @@ void cw_rx(int32_t *samples, int count) {
   cw_rx_detect_symbol(&decoder);    // detect Morse symbols
 }
 
-// finds the signal magnitude in three different frequency bins and
-// selects the strongest to tolerate mistuning
-static void cw_rx_bin(struct cw_decoder *p, int32_t *samples) {
+// look for presence of signal in this block of samples
+static void cw_rx_bin(struct cw_decoder *p, int32_t *samples){
+  // check all three frequency bins and pick the largest
   int mag_center = cw_rx_bin_detect(&p->signal_center, samples);
-  int mag_plus = cw_rx_bin_detect(&p->signal_plus, samples);
-  int mag_minus = cw_rx_bin_detect(&p->signal_minus, samples);
-
-  // Find which bin is the strongest
-  int sig_mag;    // strongest signal bin
-  int noise_mag;  // average of the other two bins (used as noise estimate)
-  if (mag_center >= mag_plus && mag_center >= mag_minus) {
-    // mag_center is the strongest
-    sig_mag = mag_center;
-    noise_mag = (mag_plus + mag_minus) / 2;
-  } else if (mag_plus >= mag_center && mag_plus >= mag_minus) {
-    // mag_plus is the strongest
-    sig_mag = mag_plus;
-    noise_mag = (mag_center + mag_minus) / 2;
-  } else {
-    // mag_minus is the strongest
-    sig_mag = mag_minus;
-    noise_mag = (mag_center + mag_plus) / 2;
-  }
-
-  // compute SNR and compare to threshold
-  float snr = (float)sig_mag / (noise_mag + 1.0f);  // avoid div by zero
-  p->magnitude = sig_mag;
-  // if SNR exceeds threshold then signal present
-  if (snr > SNR_THRESHOLD) {
-    p->sig_state = 30000;
-  } else {
-    p->sig_state = 0;
-  }
-  p->ticker++;
+  int mag_plus   = cw_rx_bin_detect(&p->signal_plus, samples);
+  int mag_minus  = cw_rx_bin_detect(&p->signal_minus, samples);
+  int sig_now = mag_center;
+  if (mag_plus > sig_now)  sig_now = mag_plus;
+  if (mag_minus > sig_now) sig_now = mag_minus;
+	
+	// compare to recent magnitude levels to see if signal present
+  p->magnitude = sig_now;
+	if (p->magnitude > (p->high_level * 6)/10){
+			p->sig_state = 30000;
+	}
+	else if (p->magnitude <  (p->high_level * 4)/10 ){ 
+		p->sig_state = 0;
+	}
+	p->ticker++;
 }
 
 // use Goertzel algorithm to detect the magnitude of a specific frequency bin


### PR DESCRIPTION
- decrease sensitivity to small tuning errors
- adjust sliding window usage to denoise input
- add signal detection hysterisis
- comment additions and cleanup

I think the bulk of the cw decoder part of this file has been little changed since version 3. I read through it (with my editor open) several times, and tried to understand and document how things work. It still follows the original concept, but things are nicer now, better organized, comments added or corrected. I hope people are ok with extensive edits and code moving around - for someone just starting to work on it modem_cw.c is in a better starting place now!