### PR TITLE
improved cw decoder in modem_cw.c

### DIFF
--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -1222,8 +1222,6 @@ void cw_init(){
   cw_rx_bin_init(&decoder.signal_center, INIT_TONE, N_BINS, SAMPLING_FREQ);
   cw_rx_bin_init(&decoder.signal_plus1,  INIT_TONE + 50, N_BINS, SAMPLING_FREQ);
   cw_rx_bin_init(&decoder.signal_plus2,  INIT_TONE + 100, N_BINS, SAMPLING_FREQ);
-
-  max_bin_idx = 0;
   
 	//init cw tx with some reasonable values
   //cw_env shapes the envelope of the cw waveform


### PR DESCRIPTION
- decrease sensitivity to small tuning errors
- adjust sliding window usage to denoise input
- add signal detection hysterisis
- use additional bins for probabilistic detection
- comment additions and cleanup

The cw decoder had been little changed since version 3.  I reorganized, scrubbed and updated some functions and got some improvement in performance against signals in noise.