### PR TITLE
In ft8 autorespond mode also answer to CQ calls when idle

### DIFF
--- a/src/ft8_lib/ft8/decode.h
+++ b/src/ft8_lib/ft8/decode.h
@@ -42,6 +42,7 @@ typedef struct
     // TODO: check again that this size is enough
     char text[25]; ///< Plain text
     uint16_t hash; ///< Hash value to be used in hash table and quick checking for duplicates
+    char displaytext[64]; ///< The text that is parsable by ft8_process
 } message_t;
 
 /// Structure that contains the status of various steps during decoding of a message

--- a/src/modem_ft8.h
+++ b/src/modem_ft8.h
@@ -5,4 +5,4 @@ void ft8_abort();
 void ft8_tx(char *message, int freq);
 void ft8_poll(int seconds, int tx_is_on);
 float ft8_next_sample();
-void ft8_process(char *message, int operation);
+int ft8_process(char *message, int operation);

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -55,7 +55,7 @@ extern int calculate_s_meter(struct rx *r, double rx_gain);
 extern struct rx *rx_list;
 #define FT8_START_QSO 1
 #define FT8_CONTINUE_QSO 0
-void ft8_process(char *received, int operation);
+int ft8_process(char *received, int operation);
 void change_band(char *request);
 void highlight_band_field(int new_band);
 /* command  buffer for commands received from the remote */


### PR DESCRIPTION
In ft8 autorespond mode also answer to CQ calls when idle. Avoid answering to the same stations again.
(rebased for the "snr" branch)