### PR TITLE
zerobeat display enhancement

### DIFF
--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -776,6 +776,15 @@ static void cw_rx_bin(struct cw_decoder *p, int32_t *samples) {
   p->ticker++;
 }
 
+// this function only called from sbitx_gtk.c to supply zerobeat indicator 
+// with info on which bin to highlight
+int cw_get_max_bin_highlight_index(void) {
+  // return -1 if no signal present or if no streak (I might tune the streak number)
+  if (!decoder.sig_state) return -1;
+  if (decoder.max_bin_streak < 2) return -1;
+  return decoder.max_bin_idx; // 0..4, where 2 is the center bin
+}
+
 // use fractional Goertzel algorithm to detect the magnitude of a specific frequency bin
 static int cw_rx_bin_detect(struct bin *p, int32_t *data) {
   // Q1 and Q2 are the previous two states in the Goertzel recurrence

--- a/src/modem_cw.h
+++ b/src/modem_cw.h
@@ -6,6 +6,9 @@ void cw_tx(char *message, int freq);
 void cw_poll(int bytes_available, int tx_is_on);
 float cw_next_sample();
 
+// added to support zerobeat display of cw decoder status
+int cw_get_max_bin_highlight_index(void);
+
 #define N_BINS 128
 #define INIT_TONE 600
 #define SAMPLING_FREQ 12000

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -3011,7 +3011,7 @@ void draw_spectrum(struct field *f_spectrum, cairo_t *gfx)
         const double fh = box_height + 2 * pad;
   
         // use cyan color for the frame (cyan is r=0.0, g=1.0, b=1.0)
-        cairo_set_source_rgba(gfx, 0.0, 1.0, 1.0, 0.3);  // make frame 30% opaque
+        cairo_set_source_rgba(gfx, 0.0, 1.0, 1.0, 0.4);  // make frame 40% opaque
         cairo_set_line_width(gfx, line_w);
         cairo_rectangle(gfx, fx, fy, fw, fh);
         cairo_stroke(gfx);

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -42,6 +42,7 @@ The initial sync between the gui values, the core radio values, settings, et al 
 #include "hamlib.h"
 #include "remote.h"
 #include "modem_ft8.h"
+#include "modem_cw.h"
 #include "i2cbb.h"
 #include "webserver.h"
 #include "logbook.h"
@@ -2937,86 +2938,88 @@ void draw_spectrum(struct field *f_spectrum, cairo_t *gfx)
 
 	cairo_stroke(gfx);
 
-	if (zero_beat_enabled)
-	{
-		// --- Zero Beat indicator
-		const char *zerobeat_text = "ZBEAT";
-		cairo_set_font_size(gfx, FONT_SMALL);
-	
-		
-		// Only show zero beat indicator in CW/CWR modes
-		if (!strcmp(mode_f->value, "CW") || !strcmp(mode_f->value, "CWR")) {
-			// Get zero beat value from calculate_zero_beat
-			int zerobeat_value = calculate_zero_beat(rx_list, 96000.0);
-	
-	
-			// Position and draw the text in gray
-			int zerobeat_text_x = f_spectrum->x + f_spectrum->width - measure_text(gfx, (char *)zerobeat_text, FONT_SMALL) - 183 ;
-			int zerobeat_text_y = f_spectrum->y + 30;
-	
-			// Draw text in gray always
-			cairo_set_source_rgb(gfx, 0.2, 0.2, 0.2); // Gray text
-			cairo_move_to(gfx, zerobeat_text_x, zerobeat_text_y);
-			cairo_show_text(gfx, zerobeat_text);
-	
-			// Draw LED indicators
-			int box_width = 15;
-			int box_height = 5;
-			int spacing = 2;
-			int led_y = zerobeat_text_y - 5;
-			int led_x = zerobeat_text_x + measure_text(gfx, (char *)zerobeat_text, FONT_SMALL) + 5;
-	
-			// Draw LED background
-			cairo_save(gfx);
-			cairo_set_source_rgba(gfx, 0.0, 0.0, 0.0, 0.5);
-			cairo_rectangle(gfx, led_x - 2, led_y - 2, 
-						   (box_width + spacing) * 5 + 4, box_height + 4);
-			cairo_fill(gfx);
-	
-			// Draw 5 LEDs
-	
-			
-			for(int i = 0; i < 5; i++) {
-				cairo_rectangle(gfx, led_x + i * (box_width + spacing), led_y, box_width, box_height);
-				
-				// Set LED color based on zero beat value and position
-				if (i == 0 && zerobeat_value == 1) { // Far below
-		
-		
-					cairo_set_source_rgb(gfx, 1.0, 0.0, 0.0);
-				}
-				else if (i == 1 && zerobeat_value == 2) { // Slightly below
-		
-		
-					cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0);
-				}
-				else if (i == 2 && zerobeat_value == 3) { // Centered
-		
-		
-					cairo_set_source_rgb(gfx, 0.0, 1.0, 0.0);
-				}
-				else if (i == 3 && zerobeat_value == 4) { // Slightly above
-		
-		
-					cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0);
-				}
-				else if (i == 4 && zerobeat_value == 5) { // Far above
-		
-		
-					cairo_set_source_rgb(gfx, 1.0, 0.0, 0.0);
-				}
-				else {
-		
-		
-					cairo_set_source_rgb(gfx, 0.2, 0.2, 0.2); // Inactive LED
-				}
-	
-				cairo_fill(gfx);
-			}
-			cairo_restore(gfx);
-		}
-	}
-
+	if (zero_beat_enabled) {
+    // --- Zero Beat indicator
+    const char *zerobeat_text = "ZBEAT";
+    cairo_set_font_size(gfx, FONT_SMALL);
+  
+    // Only show zero beat indicator in CW/CWR modes
+    if (!strcmp(mode_f->value, "CW") || !strcmp(mode_f->value, "CWR")) {
+      // Get zero beat value from calculate_zero_beat
+      int zerobeat_value = calculate_zero_beat(rx_list, 96000.0);
+  
+      // Position and draw the text in gray
+      int zerobeat_text_x = f_spectrum->x + f_spectrum->width -
+                            measure_text(gfx, (char *)zerobeat_text, FONT_SMALL) -
+                            183;
+      int zerobeat_text_y = f_spectrum->y + 30;
+  
+      // Draw text in gray always
+      cairo_set_source_rgb(gfx, 0.2, 0.2, 0.2);  // Gray text
+      cairo_move_to(gfx, zerobeat_text_x, zerobeat_text_y);
+      cairo_show_text(gfx, zerobeat_text);
+  
+      // Draw LED indicators
+      int box_width = 15;
+      int box_height = 5;
+      int spacing = 2;
+      int led_y = zerobeat_text_y - 5;
+      int led_x = zerobeat_text_x +
+                  measure_text(gfx, (char *)zerobeat_text, FONT_SMALL) + 5;
+  
+      // Draw LED background
+      cairo_save(gfx);
+      cairo_set_source_rgba(gfx, 0.0, 0.0, 0.0, 0.5);
+      cairo_rectangle(gfx, led_x - 2, led_y - 2, (box_width + spacing) * 5 + 4,
+                      box_height + 4);
+      cairo_fill(gfx);
+  
+      // Draw 5 LEDs
+      for (int i = 0; i < 5; i++) {
+        cairo_rectangle(gfx, led_x + i * (box_width + spacing), led_y, box_width,
+                        box_height);
+  
+        // Set LED color based on zero beat value and position
+        if (i == 0 && zerobeat_value == 1) {  // Far below
+          cairo_set_source_rgb(gfx, 1.0, 0.0, 0.0);
+        } else if (i == 1 && zerobeat_value == 2) {  // Slightly below
+          cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0);
+        } else if (i == 2 && zerobeat_value == 3) {  // Centered
+          cairo_set_source_rgb(gfx, 0.0, 1.0, 0.0);
+        } else if (i == 3 && zerobeat_value == 4) {  // Slightly above
+          cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0);
+        } else if (i == 4 && zerobeat_value == 5) {  // Far above
+          cairo_set_source_rgb(gfx, 1.0, 0.0, 0.0);
+        } else {
+          // Inactive background color
+          cairo_set_source_rgb(gfx, 0.13, 0.13, 0.13);
+        }
+  
+        cairo_fill(gfx);
+      }
+  
+      // Draw a highlight frame around the LED corresponding to the CW decoder's
+      // strongest bin Mapping is left-to-right: 0:-80 Hz, 1:-35 Hz, 2:0 Hz, 3:+35
+      // Hz, 4:+80 Hz
+      int hi = cw_get_max_bin_highlight_index();
+      if (hi >= 0 && hi < 5) {
+        const double pad = 2.0;     // frame padding around the LED box
+        const double line_w = 2.0;  // frame thickness
+        const double fx = led_x + hi * (box_width + spacing) - pad;
+        const double fy = led_y - pad;
+        const double fw = box_width + 2 * pad;
+        const double fh = box_height + 2 * pad;
+  
+        // Use a distinct color for the frame; cyan stands out across LED colors
+        cairo_set_source_rgb(gfx, 0.0, 1.0, 1.0);
+        cairo_set_line_width(gfx, line_w);
+        cairo_rectangle(gfx, fx, fy, fw, fh);
+        cairo_stroke(gfx);
+      }
+      cairo_restore(gfx);
+    }
+  }  
+  
 	// draw the frequency readout at the bottom
 	cairo_set_source_rgb(gfx, palette[COLOR_TEXT_MUTED][0],
 						 palette[COLOR_TEXT_MUTED][1], palette[COLOR_TEXT_MUTED][2]);

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -3011,7 +3011,7 @@ void draw_spectrum(struct field *f_spectrum, cairo_t *gfx)
         const double fh = box_height + 2 * pad;
   
         // use cyan color for the frame (cyan is r=0.0, g=1.0, b=1.0)
-        cairo_set_source_rgba(gfx, 0.0, 1.0, 1.0, 0.5);  // make frame 50% opaque
+        cairo_set_source_rgba(gfx, 0.0, 1.0, 1.0, 0.3);  // make frame 30% opaque
         cairo_set_line_width(gfx, line_w);
         cairo_rectangle(gfx, fx, fy, fw, fh);
         cairo_stroke(gfx);

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -3010,8 +3010,8 @@ void draw_spectrum(struct field *f_spectrum, cairo_t *gfx)
         const double fw = box_width + 2 * pad;
         const double fh = box_height + 2 * pad;
   
-        // Use a distinct color for the frame; cyan stands out across LED colors
-        cairo_set_source_rgb(gfx, 0.0, 1.0, 1.0);
+        // use cyan color for the frame (cyan is r=0.0, g=1.0, b=1.0)
+        cairo_set_source_rgba(gfx, 0.0, 1.0, 1.0, 0.5);  // make frame 50% opaque
         cairo_set_line_width(gfx, line_w);
         cairo_rectangle(gfx, fx, fy, fw, fh);
         cairo_stroke(gfx);


### PR DESCRIPTION
- add a frame around each of the zerobeat 'leds' when the cw decoder detects a signal in that bin

This could be useful to someone working on enhancing the cw decoder in the future.  It doesn't take up much screen space but folks wanting to keep superfluous stuff out of the UI might not like it ...