### PR TITLE
frequency encoder enhancement

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -105,12 +105,14 @@ char pins[15] = {0, 2, 3, 6, 7,
 #define ENC2_B (2)
 #define ENC2_SW (3)
 
+#define ENCODER_DEBOUNCE_US 150  // ignore edges that arrive before this many microseconds
+
 #define SW5 (22)
 #define PTT (7)
 #define DASH (21)
 
-#define ENC_FAST 1
-#define ENC_SLOW 5
+#define ENC_FAST 4
+#define ENC_SLOW 5    // not used anywhere?
 
 #define DS3231_I2C_ADD 0x68
 // time sync, when the NTP time is not synced, this tracks the number of seconds
@@ -146,6 +148,7 @@ struct encoder
 	int speed;
 	int prev_state;
 	int history;
+  unsigned int last_us;  // last accepted transition time (microseconds)
 };
 void tuning_isr(void);
 
@@ -6408,74 +6411,75 @@ int key_poll() {
     }
   return key;
 }
+        
+// read the two output pins on the encoder
+int enc_state(struct encoder *e)
+{
+	return (digitalRead(e->pin_a) ? 1 : 0) + (digitalRead(e->pin_b) ? 2 : 0);
+}
 
 void enc_init(struct encoder *e, int speed, int pin_a, int pin_b)
 {
 	e->pin_a = pin_a;
 	e->pin_b = pin_b;
 	e->speed = speed;
-	e->history = 5;
+	e->history = 0;
+  e->prev_state = enc_state(e) & 0x3;  // capture current encoder state
+  e->last_us = micros();               // and time
 }
 
-int enc_state(struct encoder *e)
-{
-	return (digitalRead(e->pin_a) ? 1 : 0) + (digitalRead(e->pin_b) ? 2 : 0);
+// read encoder output and determine rotation direction
+int enc_read(struct encoder *e) {
+  // 4x4 transition table, index = (prev<<2) | curr
+  // entries: -1 = CCW, +1 = CW, 0 = no movement/invalid
+  static const int8_t qdec[16] = {
+    /* prev=00 */  0, +1, -1,  0,
+    /* prev=01 */ -1,  0,  0, +1,
+    /* prev=10 */ +1,  0,  0, -1,
+    /* prev=11 */  0, -1, +1,  0 };
+
+  // debounce just ignores transitions that arrive too quickly
+  unsigned int now = micros();
+  if ((unsigned int)(now - e->last_us) < ENCODER_DEBOUNCE_US) {
+    return 0;
+  }
+
+  // determine direction of knob rotation
+  int curr = enc_state(e) & 0x3;  // current A/B state (00..11)
+  int idx = ((e->prev_state & 0x3) << 2) | curr;  // idx is 4 bits
+  int step = qdec[idx];  // use transition table to determine direction (-1, 0, +1)
+
+  // if no logical movement, keep time loose (don’t update last_us)
+  if (step == 0) {
+    e->prev_state = curr;
+    return 0;
+  }
+  // accept this movement, update timestamp and previous state
+  e->last_us = now;
+  e->prev_state = curr;
+
+  // accumulate steps into history to implement 'speed' threshold
+  e->history += step;
+
+  // report a tick once accumulated movement passes threshold
+  // 'speed' is number of steps required to make a movement
+  if (e->history >= e->speed) {
+    e->history = 0;
+    return +1;  // CW tick
+  } else if (e->history <= -e->speed) {
+    e->history = 0;
+    return -1;  // CCW tick
+  }
+  return 0;  // not enough accumulated movement yet
 }
 
-int enc_read(struct encoder *e)
-{
-	int result = 0;
-	int newState;
-
-	newState = enc_state(e); // Get current state
-
-	if (newState != e->prev_state)
-		delay(1);
-
-	if (enc_state(e) != newState || newState == e->prev_state)
-		return 0;
-
-	// these transitions point to the encoder being rotated anti-clockwise
-	if ((e->prev_state == 0 && newState == 2) ||
-		(e->prev_state == 2 && newState == 3) ||
-		(e->prev_state == 3 && newState == 1) ||
-		(e->prev_state == 1 && newState == 0))
-	{
-		e->history--;
-		// result = -1;
-	}
-	// these transitions point to the enccoder being rotated clockwise
-	if ((e->prev_state == 0 && newState == 1) ||
-		(e->prev_state == 1 && newState == 3) ||
-		(e->prev_state == 3 && newState == 2) ||
-		(e->prev_state == 2 && newState == 0))
-	{
-		e->history++;
-	}
-	e->prev_state = newState; // Record state for next pulse interpretation
-	if (e->history > e->speed)
-	{
-		result = 1;
-		e->history = 0;
-	}
-	if (e->history < -e->speed)
-	{
-		result = -1;
-		e->history = 0;
-	}
-	return result;
+static volatile int tuning_ticks = 0;
+void tuning_isr(void) {
+  int tuning = enc_read(&enc_b);
+  if (tuning < 0) tuning_ticks++;
+  if (tuning > 0) tuning_ticks--;
 }
-
-static int tuning_ticks = 0;
-void tuning_isr(void)
-{
-	int tuning = enc_read(&enc_b);
-	if (tuning < 0)
-		tuning_ticks++;
-	if (tuning > 0)
-		tuning_ticks--;
-}
-
+        
 void query_swr()
 {
 	uint8_t response[4];

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -4670,7 +4670,7 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
     // measure time between tuning steps and keep weighted moving average
     static uint64_t last_us = 0;
     static double ema_rate = 0.0;  // events per second, smoothed
-    const double alpha = 0.25;     // moving average factor; higher = more responsive
+    const double alpha = 0.20;     // moving average factor; higher = more responsive
 
     int base_step = tuning_step;  // keep user step chosen in UI is immutable per event
     int local_step = base_step;   // computed each event
@@ -4690,15 +4690,13 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
 
           // set tuning rate multiplier based on average rate
           int mult;
-          if (ema_rate < 5.0)
+          if (ema_rate < 10.0)
             mult = 1;
           else if (ema_rate < 20.0)
             mult = 5;
-          else if (ema_rate < 50.0)
+          else     // ema_rate > 20.0
             mult = 10;
-          else
-            mult = 100;
-
+         
           // set a max tuning rate
           // consider user selecting 10Khz tuning step size we wouldn't want to exceed 50K
           long cap = 50000;

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -4691,14 +4691,16 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
           // set tuning rate multiplier based on average rate
           int mult;
           if (ema_rate < 10.0)
-            mult = 1;
+            mult = 1;    // 10 Hz steps stay at 10 Hz with slow turns
           else if (ema_rate < 20.0)
-            mult = 5;
-          else     // ema_rate > 20.0
-            mult = 10;
+            mult = 5;    // 10 Hz steps become 50 Hz steps
+          else if (ema_rate < 40.0)
+            mult = 10;    // 10 Hz steps become 100 Hz steps
+          else   // ema_rate > 40.0
+            mult = 50;    // 10 Hz steps become 500 Hz steps
          
           // set a max tuning rate
-          // consider user selecting 10Khz tuning step size we wouldn't want to exceed 50K
+          // consider user selecting 10Khz tuning step size we wouldn't want to exceed 50K steps
           long cap = 50000;
           long proposed = (long)base_step * mult;
           if (proposed > cap) proposed = cap;

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -4670,7 +4670,7 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
     // measure time between tuning steps and keep weighted moving average
     static uint64_t last_us = 0;
     static double ema_rate = 0.0;  // events per second, smoothed
-    const double alpha = 0.20;     // moving average factor; higher = more responsive
+    const double alpha = 0.50;     // moving average factor; higher = more responsive
 
     int base_step = tuning_step;  // keep user step chosen in UI is immutable per event
     int local_step = base_step;   // computed each event
@@ -4688,16 +4688,16 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
           // compute weighted moving average
           ema_rate = (alpha * inst_rate) + (1.0 - alpha) * ema_rate;
 
-          // set tuning rate multiplier based on average rate
+          // set tuning rate multiplier based on weighted moving average rate
           int mult;
-          if (ema_rate < 10.0)
+          if (ema_rate < 15.0)
             mult = 1;    // 10 Hz steps stay at 10 Hz with slow turns
-          else if (ema_rate < 20.0)
-            mult = 5;    // 10 Hz steps become 50 Hz steps
-          else if (ema_rate < 40.0)
+          else if (ema_rate < 30.0)
             mult = 10;    // 10 Hz steps become 100 Hz steps
-          else   // ema_rate > 40.0
+          else if (ema_rate < 45.0)
             mult = 50;    // 10 Hz steps become 500 Hz steps
+          else   // ema_rate > 45.0
+            mult = 100;   // 10 Hz steps become 1000 Hz steps
          
           // set a max tuning rate
           // consider user selecting 10Khz tuning step size we wouldn't want to exceed 50K steps


### PR DESCRIPTION
The frequency encoder control on my sbitx has always seemed a little 'jumpy'.  I have reworked the encoder read function and the 'acceleration' code in do_tuning().

In the encoder read code
- got rid of the 1 ms delay used in debounce
- have a fast 16 element array to lookup every possible combination of encoder transitions so the direction of travel can be read out directly and 'illegal' glitchy transitions can be ignored
In do_tuning
- based on the time of arrival of tuning inputs we calculate the rate of the knob turning
- we keep a moving average of tuning rate
- for slow turns we just use the tuning rate the user has selected in the UI
- as we turn the knob faster we multiply the user selected rate by some factor

Note that the command to turn Tuning Acceleration on (\TA ON) still must be on to see acceleration work.  The old tuning acceleration rate 1 and 2 are still in the code but they don't do anything ... 