### PR TITLE
adjust tuning rate thresholds

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -4673,7 +4673,7 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
     // measure time between tuning steps and keep weighted moving average
     static uint64_t last_us = 0;
     static double ema_rate = 0.0;  // events per second, smoothed
-    const double alpha = 0.50;     // moving average factor; higher = more responsive
+    const double alpha = 0.10;     // moving average factor; higher = more responsive
 
     int base_step = tuning_step;  // keep user step chosen in UI is immutable per event
     int local_step = base_step;   // computed each event
@@ -4693,13 +4693,11 @@ int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c) {
 
           // set tuning rate multiplier based on weighted moving average rate
           int mult;
-          if (ema_rate < 15.0)
+          if (ema_rate < 25.0)
             mult = 1;    // 10 Hz steps stay at 10 Hz with slow turns
-          else if (ema_rate < 30.0)
+          else if (ema_rate < 35.0)
             mult = 10;    // 10 Hz steps become 100 Hz steps
-          else if (ema_rate < 45.0)
-            mult = 50;    // 10 Hz steps become 500 Hz steps
-          else   // ema_rate > 45.0
+          else   // ema_rate > 35.0
             mult = 100;   // 10 Hz steps become 1000 Hz steps
          
           // set a max tuning rate


### PR DESCRIPTION
- makes tuning rate changes smoother (instead of averaging last two intervals we now average ten)
- adjust tuning rate 'break points' for better feel