### PR TITLE
cherrypicked RIT changes from jb_rit branch

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -559,7 +559,7 @@ void cmd_exec(char *cmd);
 
 int do_spectrum(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_waterfall(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
-int (struct field *f, cairo_t *gfx, int event, int a, int b, int c);
+int do_tuning(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_text(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_status(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
 int do_console(struct field *f, cairo_t *gfx, int event, int a, int b, int c);
@@ -637,7 +637,7 @@ struct field main_controls[] = {
 	 "OFF/SLOW/MED/FAST", 0, 1024, 1, COMMON_CONTROL},
 	{"tx_power", NULL, 580, 5, 40, 40, "DRIVE", 40, "40", FIELD_NUMBER, FONT_FIELD_VALUE,
 	 "", 1, 100, 1, COMMON_CONTROL},
-	{"r1:freq", , 600, 0, 150, 49, "FREQ", 5, "14000000", FIELD_NUMBER, FONT_LARGE_VALUE,
+	{"r1:freq", do_tuning, 600, 0, 150, 49, "FREQ", 5, "14000000", FIELD_NUMBER, FONT_LARGE_VALUE,
 	 "", 500000, 32000000, 100, COMMON_CONTROL},
 	{"#vfo_keypad_overlay", do_vfo_keypad, 600, 0, 75, 49, "", 0, "", FIELD_STATIC, FONT_FIELD_VALUE,
 	 "", 0, 0, 0, COMMON_CONTROL},


### PR DESCRIPTION
9ecc171 Added red RIT indicator
8e4e0d2 added scope edge indicator
85fbf8d added do_rit_control ...
0a621c3 added enhanced RIT control ...

edited do_tuning()
- note that there is no tuning acceleration when RIT is on, it just uses the selected tuning rate