### PR TITLE
Keyboard alignment fixes

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -3846,7 +3846,6 @@ static void layout_ui()
     // Use the exact keyboard height to avoid off-by-one layout overlaps
     y2 = screen_height - KEYBOARD_HEIGHT;  
     keyboard_display(1);
-	field_move("KBD", screen_width - 48, screen_height - 37, 45, 37);
   } else {
     keyboard_display(0);
   }


### PR DESCRIPTION
Adding Left/Right/Bottom padding to keyboard.  
<img width="856" height="256" alt="image" src="https://github.com/user-attachments/assets/26147c06-9171-4f15-a9b3-362807a4e953" />


Prior to  change.  Notice left alignment with CQ as well as border being cut off left, right, and bottom. 

<img width="881" height="264" alt="image" src="https://github.com/user-attachments/assets/8f64d24b-b321-448e-9511-189f37aa0415" />