### PR TITLE
2 decimals for voltage and current

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -3626,7 +3626,7 @@ void draw_dial(struct field *f, cairo_t *gfx)
 
 	// Draw voltage readout if INA260 is available
 	if (has_ina260 == 1 && voltage > 0.0f) {
-		sprintf(buff, "%.1fV", voltage);
+		sprintf(buff, "%.2fV", voltage);
 
 		// Get voltage thresholds from user settings
 		struct field *warn_v = get_field("#warn_voltage");
@@ -3644,7 +3644,7 @@ void draw_dial(struct field *f, cairo_t *gfx)
 
 		// Set color based on voltage level (after set_style to override default color)
 		if( in_tx ){
-			sprintf(buff, "%.1fA", current);
+			sprintf(buff, "%.2fA", current);
 			cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0); // Yellow to match SWR indicator during TX
 		} else if (voltage >= warn_voltage) {
 			cairo_set_source_rgb(gfx, 0.0, 1.0, 0.0); // Green - good


### PR DESCRIPTION
Added 2 decimal points for both Voltage and Current in GTK display. 
<img width="245" height="123" alt="image" src="https://github.com/user-attachments/assets/5b3ae5dc-8e60-4e87-8aa3-0acca6d4d1b6" />

<img width="301" height="135" alt="image" src="https://github.com/user-attachments/assets/d1e834e2-e021-4ede-96e5-51ef6897ce5b" />

Worst case is when Rit or Split is enabled: 

<img width="308" height="123" alt="image" src="https://github.com/user-attachments/assets/46de3284-1dfe-4421-8304-3c5e02cb806d" />
