### PR TITLE
persnickety pixel pushing

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -667,7 +667,7 @@ struct field main_controls[] = {
 	 "", 0, 0, 0, COMMON_CONTROL},
 	{"#80m", NULL, 370, 5, 40, 40, "80M", 1, "", FIELD_BUTTON, FONT_FIELD_VALUE,
 	 "", 0, 0, 0, COMMON_CONTROL},
-	{"#record", do_record, 459, 5, 40, 40, "REC", 40, "OFF", FIELD_TOGGLE, FONT_FIELD_VALUE,
+	{"#record", do_record, 410, 5, 40, 40, "REC", 40, "OFF", FIELD_TOGGLE, FONT_FIELD_VALUE,
 	 "ON/OFF", 0, 0, 0, COMMON_CONTROL},
 	{"#tune", do_toggle_option, 460, 5, 40, 40, "TUNE", 40, "", FIELD_TOGGLE, FONT_FIELD_VALUE,
 	 "ON/OFF", 0, 0, 0, COMMON_CONTROL},


### PR DESCRIPTION
Some UI tweaks and spacing issues on the top.  
- Moved REC button over MENU
- Adjusted spacing between Menu so that the spacing is roughly equal on both sides. 
- Adjusted SPLIT/VFO/SPAN/AGC/BW/DRIVE to fit in the space evenly. 

Before: 
<img width="798" height="160" alt="image" src="https://github.com/user-attachments/assets/1f814a30-1c58-4759-9603-ae8e32e707f8" />


After: 
<img width="799" height="262" alt="image" src="https://github.com/user-attachments/assets/237ef395-c6fa-47d4-b20a-121888879913" />
