### PR TITLE
"snap" command

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -391,7 +391,7 @@ static int take_screenshot_desktop(void) {
   gmtime_r(&now, &tm_now);
 
   char filename[512];
-  snprintf(filename, sizeof(filename), "%s/screenshot-%04d%02d%02d-%02d%02d%02d.png",
+  snprintf(filename, sizeof(filename), "%s/snap-%04d%02d%02d-%02d%02d%02d.png",
            dirpath, tm_now.tm_year + 1900, tm_now.tm_mon + 1, tm_now.tm_mday,
            tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec);
 


### PR DESCRIPTION
This command checks the size of display screen being used and takes a full screen snap-shot.
Run it by typing \snap in the text window (remote calls should work too)
Creates a .png file named snap, with date and time snap
Uses built in GTK functions, no external libraries added.
I inserted the code and commands near the audio "REC" function, so now sbitx can record audio AND take snapshots (but I did not add a visible control for SNAP - it is by command only ...)


