### PR TITLE
Prompting user to enter USB mode for calibration. 

### DIFF
--- a/src/calibration_ui.c
+++ b/src/calibration_ui.c
@@ -303,6 +303,20 @@ void calibration_ui(GtkWidget *parent) {
     GtkWidget *dialog, *grid, *label, *button;
     int row = 0;
 
+    // Check if we're in USB mode
+    const char *current_mode = field_str("MODE");
+    if (!current_mode || strcmp(current_mode, "USB") != 0) {
+        GtkWidget *msg_dialog = gtk_message_dialog_new(
+            GTK_WINDOW(parent),
+            GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_MESSAGE_WARNING,
+            GTK_BUTTONS_OK,
+            "Switch to USB mode and then reopen this dialog.");
+        gtk_dialog_run(GTK_DIALOG(msg_dialog));
+        gtk_widget_destroy(msg_dialog);
+        return;
+    }
+
     // Initialize calibration state
     memset(&cal_state, 0, sizeof(cal_state));
     cal_state.selected_band = 0;  // Default to 80M


### PR DESCRIPTION
This will no doubt annoy me for a long while.  But I was not able to reliably set the MODE to USB for the Calibration Dialog.  Lots of attempts were made and there was always an issue where under certain circumstances the output would not work.  Just a brief "pop" and then no calibration tone.  

So for now the work around is to prevent entry into the calibration dialog when the mode is not USB.  😭 

<img width="800" height="479" alt="image" src="https://github.com/user-attachments/assets/704a7d41-dc36-4997-a20f-88e3c56e5212" />
