### PR TITLE
Log Output Additions for External Parsing and Auto-Logging

### DIFF
--- a/src/modem_ft8.c
+++ b/src/modem_ft8.c
@@ -30,6 +30,8 @@
 static char ft8_already_called[FT8_CALLED_SIZE][32];
 static int ft8_already_called_n = 0;
 
+extern int tx_peak_power_tenths;  // Used to reset the peak power settings per each communication
+
 static int32_t ft8_rx_buff[FT8_MAX_BUFF];
 static float ft8_rx_buffer[FT8_MAX_BUFF];
 static float ft8_tx_buff[FT8_MAX_BUFF];
@@ -845,6 +847,9 @@ void ft8_on_start_qso(char *message){
 	modem_abort();
 	tx_off();
 	call_wipe();
+	
+    // reset the FT8 peak power at the *start* of a new QSO
+    tx_peak_power_tenths = 0;	
 
 	//for cq message that started on 0 or 30th second, use the 15 or 45 and
 	//vice versa


### PR DESCRIPTION
External logging software uses frequency, date and time as well as power used. Added to expose via telnet. 

modem_ft8.c
  - Added tx_peak_power_tenths external variable
  - Reset peak power on new conversation
  - Reset tx_peak_power_tenths in ft8_on_start_qso()

 sbitx_gtk.c
  - Added tx_peak_power_tenths global variable to hold the max transmitted power per qso
   - Added tx_peak_power_tenths in enter_qso() for log output
   - Added time string for log output
   - Added tx_freq_hz (frequency) variable for log output
 
 