### PR TITLE
Detect and restyle CQ calls & grids from previous QSOs; don't call them

### DIFF
--- a/src/hist_disp.c
+++ b/src/hist_disp.c
@@ -96,11 +96,6 @@ int hd_message_parse(struct hd_message_struct* p_message, const char* raw_messag
 int ff_lookup_style(char* id, int style, int style_default) {
 	switch (style)
 	{
-	case STYLE_CALLER:
-		return logbook_caller_exists(id) ? style_default : style;
-		// return style; // test skipping log lookup
-		break;
-
 	case STYLE_GRID: {
 		bool id_ok =
 			(strlen(id) == 4 && strcmp(id,"RR73") &&
@@ -153,6 +148,8 @@ char ff_char(int style) {
 		case STYLE_CALLER:
 			return 'A' + 17;
 		case STYLE_CALLEE:
+		case STYLE_RECENT_CALLER:
+		case STYLE_EXISTING_GRID:
 			return 'A' + 5;
 		case STYLE_GRID:
 			return 'A' + 18;

--- a/src/logbook.h
+++ b/src/logbook.h
@@ -10,8 +10,8 @@ int logbook_prev_log(const char *callsign, char *result);
 int logbook_get_grids(void (*f)(char *,int));
 void logbook_list_open();
 void logbook_open();
-bool logbook_grid_exists(char *id);
-bool logbook_caller_exists(char * id);
+time_t logbook_grid_last_qso(const char *id, int len);
+time_t logbook_last_qso(const char * callsign, int len);
 
 // ADIF export
 // start_date can be null or empty if you want all records, unrestricted

--- a/src/sdr_ui.h
+++ b/src/sdr_ui.h
@@ -22,8 +22,10 @@ typedef enum {
 	STYLE_LOG = 0,
 	STYLE_MYCALL,
 	STYLE_CALLER,
+	STYLE_RECENT_CALLER, // callsign that was logged within recent_qso_age hours
 	STYLE_CALLEE,
 	STYLE_GRID,
+	STYLE_EXISTING_GRID, // grid that is found in the logbook already
 	STYLE_TIME,
 	STYLE_SNR,
 	STYLE_FREQ,


### PR DESCRIPTION
- logbook_last_qso() returns the Unix timestamp of the last QSO with the given callsign. The prepared statement is reused each time (we will call this a lot, efficiency is important.)
- logbook_grid_last_qso() returns the Unix timestamp of the last QSO with the given grid. The prepared statement is reused each time.
- show age of last QSO with callsign and/or grid in LOG_INFO output
- a recent_qso_age setting is added: how many hours do we consider "recent"? It's 24 by default, but you can change it in user_settings.ini or with the recent_qso_age command
- in incoming messages, style recently-QSO'd caller callsigns and existing grids in dim green: they are less interesting
- in CQRESP mode, do not respond to a CQ from a callsign with which we've had a QSO within the last recent_qso_age hours