### PR TITLE
Replace logbook_grid_exists with logbook_grid_last_qso

### DIFF
--- a/src/hist_disp.c
+++ b/src/hist_disp.c
@@ -97,12 +97,13 @@ int ff_lookup_style(char* id, int style, int style_default) {
 	switch (style)
 	{
 	case STYLE_GRID: {
+		const int len = strlen(id);
 		bool id_ok =
-			(strlen(id) == 4 && strcmp(id,"RR73") &&
+			(len == 4 && strcmp(id,"RR73") &&
 			isLetter(id[0]) && isLetter(id[1]) &&
         	isDigit(id[2]) && isDigit(id[3]));
 
-			return (!id_ok || logbook_grid_exists(id)) ? style_default : style;
+			return (!id_ok || logbook_grid_last_qso(id, len)) ? style_default : style;
 			//return (!id_ok) ? style_default : style; // test skipping log lookup
 		}
 		break;


### PR DESCRIPTION
Soon I want to get rid of this: the grid-last-qso lookup already happened before we get here, so it's better not to redo it for the web UI. But let's have a quick fix in the meantime. Amends 58bf914a672a1b7b55c5a556772f331b14000f01