### PR TITLE
Add and use ftx_call_or_continue

### DIFF
--- a/src/hist_disp.c
+++ b/src/hist_disp.c
@@ -143,6 +143,7 @@ char ff_char(int style) {
 	switch (style) {
 		// console styles
 		case STYLE_LOG:
+		case STYLE_RST:
 			return 'A' + 5;
 		case STYLE_MYCALL:
 			return 'A' + 16;

--- a/src/modem_ft8.h
+++ b/src/modem_ft8.h
@@ -13,4 +13,5 @@ void ft8_tx_3f(const char* call_to, const char* call_de, const char* extra);
 void ft8_poll(int tx_is_on);
 float ft8_next_sample();
 void ft8_call(int sel_time);
+void ftx_call_or_continue(const char* line, int line_len, const text_span_semantic* spans);
 int ft8_process(char *message, ftx_operation operation);

--- a/src/sdr_ui.h
+++ b/src/sdr_ui.h
@@ -26,6 +26,7 @@ typedef enum {
 	STYLE_CALLEE,
 	STYLE_GRID,
 	STYLE_EXISTING_GRID, // grid that is found in the logbook already
+	STYLE_RST,
 	STYLE_TIME,
 	STYLE_SNR,
 	STYLE_FREQ,
@@ -93,6 +94,8 @@ void write_console(sbitx_style style, const char *text);
 // write plain text, with semantically-tagged spans that imply styling
 void write_console_semantic(const char *text, const text_span_semantic *sem, int sem_count);
 int web_get_console(char *buff, int max);
+int extract_single_semantic(const char* text, int text_len, text_span_semantic span, char *out, int outlen);
+int extract_semantic(const char* text, int text_len, const text_span_semantic* spans, sbitx_style sem, char *out, int outlen);
 
 int is_in_tx();
 void abort_tx();


### PR DESCRIPTION
do_console() no longer has responsibility to extract fields from whatever line the user clicked on: now we just hand the whole line and its spans array to ftx_call_or_continue(), which does all the work, including reimplementing the FTx state machine. This seems like a nice simplification; and it also makes it possible to resume a QSO that was aborted or timed out. It's similar to ft8_process() (which is probably obsolete), except that it's given the spans array so that it can jump more directly to the state machine without reparsing the message.

Amends d7ab3ac64043eced2eb4d08065c42e23922e0d32 which had introduced a bug: calling only ft8_call when you click on a message meant that you couldn't get it to take the next step to continue a QSO by clicking.