### PR TITLE
Improve sound device naming

### DIFF
--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -2336,7 +2336,7 @@ void setup()
 		sbitx_version = SBITX_V2;
 
 	setup_audio_codec();
-	sound_thread_start("plughw:0,0");
+	sound_thread_start("plughw:CARD=audioinjectorpi,DEV=0");
 
 	sleep(1); // why? to allow the aloop to initialize?
 
@@ -2589,3 +2589,4 @@ void sdr_request(char *request, char *response)
 	/* else
 		  printf("*Error request[%s] not accepted\n", request); */
 }
+

--- a/src/sbitx_sound.c
+++ b/src/sbitx_sound.c
@@ -1078,10 +1078,10 @@ void *sound_thread_function(void *ptr){
 	last_loopback_reset = gettime_now.tv_sec;
 
 // Open the Loopback Play Device
-//  printf("opening loopback on plughw:1,0 sound card\n");
+//  printf("opening loopback on plughw:CARD=Loopback,DEV=0 sound card\n");
 
 	for (i = 0; i < 10; i++){
-		if(sound_start_loopback_play("plughw:1,0") == 0)
+		if(sound_start_loopback_play("plughw:CARD=Loopback,DEV=0") == 0)
 			break;
 		fprintf(stderr, "*Error opening Loopback Play device");
 		delay(1000);
@@ -1104,11 +1104,11 @@ void *loopback_thread_function(void *ptr){
 	sch.sched_priority = sched_get_priority_max(SCHED_FIFO);
 	pthread_setschedparam(loopback_thread, SCHED_FIFO, &sch);
 //	printf("loopback thread is %x\n", loopback_thread);
-//  printf("opening loopback on plughw:1,0 sound card\n");	
+//  printf("opening loopback on plughw:CARD=Loopback_1,DEV=1 sound card\n");	
 
 	int i = 0;
 	for (i = 0; i < 10; i++){
-		if (sound_start_loopback_capture("plughw:2,1") == 0)
+		if (sound_start_loopback_capture("plughw:CARD=Loopback_1,DEV=1") == 0)
 			break;
 		fprintf(stderr, "*Error opening Loopback Capture device");
 		delay(1000);
@@ -1158,9 +1158,10 @@ void sound_process(int32_t *input_i, int32_t *input_q, int32_t *output_i, int32_
 }
 
 void main(int argc, char **argv){
-	sound_thread_start("plughw:0,0");
+	sound_thread_start("plughw:CARD=audioinjectorpi,DEV=0");
 	sleep(10);
 	sound_thread_stop();
 	sleep(10);
 }
 */
+


### PR DESCRIPTION
sbitx uses sound device names based on numbers, not names.  This causes problems when unexpected devices show up.  One recent example was when I was using nomachine sbitx failed to start and I saw new sound devices it created showing up in pavucontrol.  Another classic issue is when someone doesn't put "noaudio" in the config.txt line for the video driver so the hdmi sound devices get instantiated before the sbitx ones do.  The fix is simple, use the same names you get from aplay.  This is the same naming scheme we use when configuring wsjtx.