### PR TITLE
operator can set font size for text in console between 10 and 40 pt type.

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -133,7 +133,7 @@ int zero_beat_min_magnitude = 0;
 
 // bigfont control
 static int bigfont_enabled = 0;
-static int bigfont_size = 20;  // Default big font size for console
+static int bigfont_size = 18;  // Default big font size, still fits 3 lines in decoder console
 
 // INA260 I2C Address and Register Definitions
 #define INA260_ADDRESS 0x40


### PR DESCRIPTION
Added \bigfont command, allowing users to enable a larger font size for text displayed on console and adjust its size between 10 and 40.
Default bigfont is 18 pt, which fits 3 lines of cw into console height.
This begins to address requests I've seen to improve things for ops with vision issues ...
