### PR TITLE
Auto set FTx frequency on mode or band change .

### DIFF
--- a/data/default_settings.ini
+++ b/data/default_settings.ini
@@ -133,6 +133,7 @@ bridge=100
 #ftx_auto=ANS
 #ftx_cq=EVEN
 #ftx_repeat=5
+#ftx_auto_freq=ON
 #telneturl=dxc.nc7j.com:7373
 #kbd_q=Q
 #kbd_w=W

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,7 @@
     #adif_broadcast_port=2237
     ```
   + Can be used to log to a local or remote logbook.  Or to FT8battle.com 
+- FTx automatically switches to the correct frequency when the Band or Mode is changed. For example if the mode is FT4 and the band changes from 20M to 10M then the correct frequency is set.  Likewise if you are on 10M USB and change to FT8 then the correct frequency is set for 10M FT8. (Jared KJ5DTK)
 - **FTx features** (Shawn K7IHZ / LB2JK):
   + Updated to latest ft8_lib. It now labels spans in the message text so we get them identified correctly.
   + Support for non-standard calls (special stations, prefixes used while travelling, etc.)


### PR DESCRIPTION
Adds FT4/8 frequencies and automatically changes to the correct frequency based on Band and Mode.  Change is triggered via band or mode change.  Also added `ftx_auto_freq` to disable this if someone is so inclined...default is enabled.