### PR TITLE
Adds multicast support to ADIF and UDP data streams.

### DIFF
--- a/data/default_settings.ini
+++ b/data/default_settings.ini
@@ -32,11 +32,11 @@ r1:mode=FT8
 #mfqrz=
 #logbook=
 
-#adif_broadcast_enable=OFF
-#adif_destinations=129.212.188.3:2237;antares.local:2333
+#adif_enable=OFF
+#adif_destinations=129.212.188.3:2237;antares.local:2333;224.0.0.1:2238
 
-#udp_broadcast_enable=OFF
-#udp_destinations=127.0.0.1:2237;antares.local:2237
+#udp_enable=OFF
+#udp_destinations=127.0.0.1:2237;antares.local:2237;224.0.0.2:2236
 
 #text_in=
 #toggle_kbd=OFF

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -1159,12 +1159,12 @@ struct field main_controls[] = {
 	{"#telneturl", NULL, 1000, -1000, 400, 149, "TELNETURL", 70, "dxc.nc7j.com:7373", FIELD_TEXT, STYLE_SMALL,
 	 "", 0, 32, 1, 0},
 
-	{"#adif_broadcast_enable", NULL, 1000, -1000, 50, 50, "ADIF_BROADCAST", 40, "OFF", FIELD_TOGGLE, STYLE_FIELD_VALUE,
+	{"#adif_enable", NULL, 1000, -1000, 50, 50, "ADIF_ENABLE", 40, "OFF", FIELD_TOGGLE, STYLE_FIELD_VALUE,
 	 "ON/OFF", 0, 0, 0, 0},
 	{"#adif_destinations", NULL, 1000, -1000, 300, 50, "ADIF_DESTINATIONS", 140, "127.0.0.1:12060", FIELD_TEXT, STYLE_SMALL,
 	 "", 0, 255, 1, 0},
 
-	{"#udp_broadcast_enable", NULL, 1000, -1000, 50, 50, "UDP_BROADCAST", 40, "OFF", FIELD_TOGGLE, STYLE_FIELD_VALUE,
+	{"#udp_enable", NULL, 1000, -1000, 50, 50, "UDP_ENABLE", 40, "OFF", FIELD_TOGGLE, STYLE_FIELD_VALUE,
 	 "ON/OFF", 0, 0, 0, 0},
 	{"#udp_destinations", NULL, 1000, -1000, 300, 50, "UDP_DESTINATIONS", 140, "127.0.0.1:2237", FIELD_TEXT, STYLE_SMALL,
 	 "", 0, 255, 1, 0},


### PR DESCRIPTION
Multicast support for ADIF and UDP.  

**Breaking Change**
`adif_broadcast_enable` renamed to `adif_enable`
`udp_broadcast_enable` renamed to `udp_enable`

Not technically "breaking" but if this isn't set correctly then it won't work.  But should not cause an exception or anything wild.