### PR TITLE
Allow a telnet connection to query the current frequency

### DIFF
--- a/src/docs/commands.txt
+++ b/src/docs/commands.txt
@@ -7,6 +7,8 @@ These are text commands that can be entered from the keyboard
 \freq [frequency in Hz or Kilohertz]
 	You can also type just 'f' instead 'freq' 
 	if you the type '\f 7050' it will set be the same as '\freq 7050000'
+\freq ?
+        Returns the current tuned frequency
 \cwdelay [100-2000] msec. How long radio remains in transmit in CW before
 	timing out to rx. ex: "\cwdelay 500"
 \cwinput [key\keyer\kbd]

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -1456,7 +1456,7 @@ void write_console(int style, char *raw_text)
 	text = decorated;
 	web_write(style, text);
 	// move to a new line if the style has changed
-	if (style != console_style)
+	if ((style != FONT_ONLY_REMOTEAPP) && (style != console_style))
 	{
 		q_write(&q_web, '{');
 		q_write(&q_web, style + 'A');
@@ -1493,6 +1493,8 @@ void write_console(int style, char *raw_text)
 		}
 	*/
 	write_to_remote_app(style, raw_text);
+        if (style == FONT_ONLY_REMOTEAPP)
+          return;
 
 	int console_line_max = MIN(console_cols, MAX_LINE_LENGTH);
 	while (*text)
@@ -8436,20 +8438,31 @@ void cmd_exec(char *cmd)
 	}
 	else if (!strcasecmp(exec, "freq") || !strcasecmp(exec, "f"))
 	{
-		long freq = atol(args);
-		if (freq == 0)
-		{
-			write_console(FONT_LOG, "Usage: \f xxxxx (in Hz or KHz)\n");
-		}
-		else if (freq < 30000)
-			freq *= 1000;
+                if (!strcmp(args, "?")) {
+                  struct field *freq = get_field("r1:freq");
+                  if (freq && freq->value) {
+                    char buf[64];
+                    strcpy(buf, "freq: ");
+                    strcat(buf, freq->value);
+                    write_console(FONT_ONLY_REMOTEAPP, buf);
+                  }
+                
+                } else {
+			long freq = atol(args);
+			if (freq == 0)
+			{
+				write_console(FONT_LOG, "Usage: \f xxxxx (in Hz or KHz)\n");
+			}
+			else if (freq < 30000)
+				freq *= 1000;
 
-		if (freq > 0)
-		{
-			char freq_s[20];
-			sprintf(freq_s, "%ld", freq);
-			set_field("r1:freq", freq_s);
-		}
+			if (freq > 0)
+			{
+				char freq_s[20];
+				sprintf(freq_s, "%ld", freq);
+				set_field("r1:freq", freq_s);
+			}
+                }
 	}
 	else if (!strcasecmp(exec, "rit"))
 	{

--- a/src/sdr_ui.h
+++ b/src/sdr_ui.h
@@ -37,11 +37,11 @@ extern int display_freq;
 #define FONT_TELNET 13
 #define FONT_FT8_QUEUED 14
 #define FONT_FT8_REPLY 15
-
 #define FF_MYCALL 16
 #define FF_CALLER 17
 #define FF_GRID 18
 #define FONT_BLACK 19
+#define FONT_ONLY_REMOTEAPP 20
 
 #define EXT_PTT 26 //ADDED BY KF7YDU, solder lead wire to J17, which ties to pin 32. 
 extern int ext_ptt_enable;


### PR DESCRIPTION
This can be used by simple external clients that use the telnet connection to the sbitx daemon
An example is here:
https://github.com/ffurano/sbitx2pskreporter