### PR TITLE
added recommended audio level limits to local and web spectrum displays

### DIFF
--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -2693,6 +2693,14 @@ void draw_modulation(struct field *f, cairo_t *gfx)
 		cairo_line_to(gfx, f->x + i, f->y + grid_height);
 	}
 	cairo_stroke(gfx);
+	
+	int gh=grid_height/10;   // added reccomended audio limit lines	
+	cairo_set_source_rgb(gfx, 1,0,0);
+	cairo_move_to(gfx, f->x, f->y + 2*gh);
+	cairo_line_to(gfx, f->x + f->width, f->y + 2*gh);
+	cairo_move_to(gfx, f->x, f->y + 8*gh);
+	cairo_line_to(gfx, f->x + f->width, f->y + 8*gh);	
+	cairo_stroke(gfx);	
 
 	// start the plot
 	cairo_set_source_rgb(gfx, palette[SPECTRUM_PLOT][0],

--- a/web/index.html
+++ b/web/index.html
@@ -2129,9 +2129,20 @@
         }
         ctx.strokeStyle = "#333";
         ctx.stroke();
+ 
+  
 
         // Plot spectrum
         if (update.startsWith("TX")) {
+            
+        ctx.beginPath();       // added reccomended audio limit kines
+        ctx.moveTo(0, drawHeight * 2 / 10);
+        ctx.lineTo(width, drawHeight * 2 / 10); 
+        ctx.moveTo(0, drawHeight * 8 / 10);
+        ctx.lineTo(width, drawHeight * 8 / 10);                      
+        ctx.strokeStyle = "#ff0000";
+        ctx.stroke();          
+            
             ctx.beginPath();
             const centerY = drawHeight * 4.5/8; // Exactly between the middle grid lines
             // Get the first sample value normalized to -1 to 1 range


### PR DESCRIPTION
Farhan recommended audio levels based on modulation display, but it is hard to see the grid lines when transmitting. This places lines at the recommended levels to help guide use.
Both local and web are implemented.
<img width="1916" height="837" alt="levels" src="https://github.com/user-attachments/assets/626f9aef-1f3a-4b74-8abd-16825790223f" />
