### PR TITLE
audio levels

### DIFF
--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -114,7 +114,7 @@ double notch_freq = 0;		   // Notch frequency in Hz W2JON
 double notch_bandwidth = 0;	   // Notch bandwidth in Hz W2JON
 int compression_control_level; // Audio Compression level W2JON
 int txmon_control_level;	   // TX Monitor level W2JON
-int vu=0;   // vu meter
+float vmax=0.0;   // vu meter
 int get_rx_gain(void)
 {
 	// printf("rx_gain %d\n", rx_gain);
@@ -1767,14 +1767,8 @@ void tx_process(
 		__real__ fft_in[i] = i_sample;
 		__imag__ fft_in[i] = q_sample;
 		m++;
-/*		
-		if (i_sample_max > .01)
-			vu = i_sample_max/.004;
-			printf(" %.4f %d ",i_sample_max, vu); // print max in block
-		if (i_sample_max > voice_clip_level)
-			printf("\n");
-*/			
-		vu = i_sample_max/(0.1 * voice_clip_level);
+			
+		vmax = i_sample_max*1.0/voice_clip_level; // scale to 1.0
 		
 		i_sample_max=0.0;
 	}

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -1690,7 +1690,7 @@ void tx_process(
 	int m = 0;
 	int j = 0;
 	double i_sample_max = 0.0;
-	
+	double i_sample_old = 0.0;
 	// double max = -10.0, min = 10.0;
 	// gather the samples into a time domain array
 	for (i = MAX_BINS / 2; i < MAX_BINS; i++)
@@ -1729,6 +1729,8 @@ void tx_process(
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM)
 		{
 			i_sample_max = fmax(i_sample, i_sample_max); // find peak value
+			i_sample_max = 0.5 * i_sample_max + 0.5 * i_sample_old;
+			i_sample_old =  i_sample_max;  // do exponential smoothing
 			
 			if (i_sample < (-1.0 * voice_clip_level))
 				i_sample = -1.0 * voice_clip_level;
@@ -1772,7 +1774,7 @@ void tx_process(
 		if (i_sample_max > voice_clip_level)
 			printf("\n");
 */			
-		vu = i_sample_max/.004;
+		vu = i_sample_max/(0.1 * voice_clip_level);
 		
 		i_sample_max=0.0;
 	}

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -114,6 +114,7 @@ double notch_freq = 0;		   // Notch frequency in Hz W2JON
 double notch_bandwidth = 0;	   // Notch bandwidth in Hz W2JON
 int compression_control_level; // Audio Compression level W2JON
 int txmon_control_level;	   // TX Monitor level W2JON
+int vu=0;   // vu meter
 int get_rx_gain(void)
 {
 	// printf("rx_gain %d\n", rx_gain);
@@ -1688,7 +1689,8 @@ void tx_process(
 
 	int m = 0;
 	int j = 0;
-
+	double i_sample_max = 0.0;
+	
 	// double max = -10.0, min = 10.0;
 	// gather the samples into a time domain array
 	for (i = MAX_BINS / 2; i < MAX_BINS; i++)
@@ -1726,6 +1728,8 @@ void tx_process(
 		// clip the overdrive to prevent damage up the processing chain, PA
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM)
 		{
+			i_sample_max = fmax(i_sample, i_sample_max); // find peak value
+			
 			if (i_sample < (-1.0 * voice_clip_level))
 				i_sample = -1.0 * voice_clip_level;
 			else if (i_sample > voice_clip_level)
@@ -1761,6 +1765,16 @@ void tx_process(
 		__real__ fft_in[i] = i_sample;
 		__imag__ fft_in[i] = q_sample;
 		m++;
+/*		
+		if (i_sample_max > .01)
+			vu = i_sample_max/.004;
+			printf(" %.4f %d ",i_sample_max, vu); // print max in block
+		if (i_sample_max > voice_clip_level)
+			printf("\n");
+*/			
+		vu = i_sample_max/.004;
+		
+		i_sample_max=0.0;
 	}
 
 	// push the samples to the remote audio queue, decimated to 16000 samples/sec

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -65,7 +65,8 @@ extern struct rx *rx_list;
 extern char *cw_get_stats(char *buf, size_t len);
 /* VSWR trip flag Clear on band change so previous trips don't persist. */
 extern int vswr_tripped;
-extern int vu;
+extern float vmax; // vlevel meter, now with log voltage levels - not power
+float vlevels[12]= {.1, .126, .158, .2, .25, .316, .398, .5, .631, .794, 1.0, 1.26};
 void change_band(char *request);
 void highlight_band_field(int new_band);
 /* command  buffer for commands received from the remote */
@@ -2710,7 +2711,7 @@ void draw_modulation(struct field *f, cairo_t *gfx)
 	struct field *mode_f = get_field("r1:mode");   //  VU meter
 	if (!strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "LSB") || !strcmp(mode_f->value, "AM"))
 		{
-		const char *vu_text = "Vol";
+		const char *vu_text = "VLEVEL";
 		cairo_set_font_size(gfx, STYLE_SMALL);	
 		int vu_text_width = measure_text(gfx, (char *)vu_text, STYLE_SMALL);
 		// Position and draw the text in gray
@@ -2732,36 +2733,40 @@ void draw_modulation(struct field *f, cairo_t *gfx)
 		// Draw LED background
 		cairo_save(gfx);
 		cairo_set_source_rgba(gfx, 0.3, 0.3, 0.3, 0.9);
-		cairo_rectangle(gfx, led_x - 2, led_y - 2, (box_width + spacing) * 10 + 2,  // 5
+		cairo_rectangle(gfx, led_x - 2, led_y - 2, (box_width + spacing) * 12 + 2,  // 5
 						box_height + 4);
 		cairo_fill(gfx);
 		
 //		int vu_value=max(1,vu-2);	
 				// Draw 10 LEDs
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < 12; i++) {
 			cairo_rectangle(gfx, led_x + i * (box_width + spacing), led_y, box_width,
 							box_height);
 
-			// Set LED color based on vu value and position
-			if (i == 0 && vu > 1) {  // Far below
-			cairo_set_source_rgb(gfx, 0.0, 0.4, 0.0);
-			} else if (i == 1 && vu > 2) {  // very low
-			cairo_set_source_rgb(gfx, 0.0, 0.5, 0.0);
-			} else if (i == 2 && vu > 3) {  // 
+			// Set LED color based on vmax value and position
+			if (i == 0 && vmax > vlevels[i]) {  // Far below
 			cairo_set_source_rgb(gfx, 0.0, 0.6, 0.0);
-			} else if (i == 3 && vu > 5) {  // 
+			} else if (i == 1 && vmax > vlevels[i]) {  // very low
+			cairo_set_source_rgb(gfx, 0.0, 0.6, 0.0);
+			} else if (i == 2 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.0, 0.6, 0.0);
+			} else if (i == 3 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.0, 0.6, 0.0);
+			} else if (i == 4 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.0, 0.6, 0.0);
+			} else if (i == 5 && vmax > vlevels[i]) {  // 
 			cairo_set_source_rgb(gfx, 0.0, 0.7, 0.0);
-			} else if (i == 4 && vu > 6) {  // 
+			} else if (i == 6 && vmax > vlevels[i]) {  // 
 			cairo_set_source_rgb(gfx, 0.0, 0.8, 0.0);
-			} else if (i == 5 && vu > 7) {  // 
-			cairo_set_source_rgb(gfx, 0.0, 0.9, 0.0);
-			} else if (i == 6 && vu > 8) {  // 
-			cairo_set_source_rgb(gfx, 0.0, 1.0, 0.0);						
-			} else if (i == 7 && vu > 9) {  // 
-			cairo_set_source_rgb(gfx, 1.0, 1.0, 0.0);	// close		
-			} else if (i == 8 && vu > 10) {  
+			} else if (i == 7 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.0, 0.9, 0.0);			
+			} else if (i == 8 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.0, 1.0, 0.0);												
+			} else if (i == 9 && vmax > vlevels[i]) {  // 
+			cairo_set_source_rgb(gfx, 0.8, 0.8, 0.0);	// close		
+			} else if (i == 10 && vmax > vlevels[i]) {  // above
 			cairo_set_source_rgb(gfx, 1.0, 0.0, 0.0);
-			} else if (i == 9 && vu > 11) {  // far above			
+			} else if (i == 11 && vmax > vlevels[i]) {  // far above			
 			cairo_set_source_rgb(gfx, 1.0, 0.2, 0.2);						
 			} else {
 			// Inactive background color

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -2711,7 +2711,7 @@ void draw_modulation(struct field *f, cairo_t *gfx)
 	struct field *mode_f = get_field("r1:mode");   //  VU meter
 	if (!strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "LSB") || !strcmp(mode_f->value, "AM"))
 		{
-		const char *vu_text = "VLEVEL";
+		const char *vu_text = "APM";
 		cairo_set_font_size(gfx, STYLE_SMALL);	
 		int vu_text_width = measure_text(gfx, (char *)vu_text, STYLE_SMALL);
 		// Position and draw the text in gray

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -2710,7 +2710,7 @@ void draw_modulation(struct field *f, cairo_t *gfx)
 	struct field *mode_f = get_field("r1:mode");   //  VU meter
 	if (!strcmp(mode_f->value, "USB") || !strcmp(mode_f->value, "LSB") || !strcmp(mode_f->value, "AM"))
 		{
-		const char *vu_text = "VU";
+		const char *vu_text = "Vol";
 		cairo_set_font_size(gfx, STYLE_SMALL);	
 		int vu_text_width = measure_text(gfx, (char *)vu_text, STYLE_SMALL);
 		// Position and draw the text in gray


### PR DESCRIPTION
Adds an input audio peak meter for voice modes to transmit spectrum.
Samples are taken just before clipping and the meter level is on a log scale.
Low audio is indicated in green on left and indication moves to right as audio increases. Yellow indicates audio just below clipping. Red indicates audio clipped. Further red indicates audio way over clip limit.
Updates every tick.
Waveform displayed in spectrum is post clipping.
<img width="802" height="512" alt="image" src="https://github.com/user-attachments/assets/19848cff-35af-4247-be2e-8aeb2f0ee45b" />
