### PR TITLE
Rebalance

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -14,7 +14,10 @@
 	+ If the `user_style.tpl` file is not found then it will load `default_style.tpl` if it is present.
 	+ If none of these files are located, then it will load the factory style we are all used to.
 	+ There are sample styles in the data folder that can be loaded. Just have to rename one of them to user_style.tpl
-  
+ - Added mode_bal to hw_settings.ini to balance LSB and CWR to USB and CW. 
+	+ 0.8 is a reasonable value. 
+	+ Also harmonized filter band edges.
+	+ removed old ssb_val 
 **Changes:**
 - GUI
 	+ Moved Direct Frequency Keypad to a new button called PAD and added quick buttons

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -1,4 +1,3 @@
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -26,6 +25,17 @@
 #include "swr_monitor.h"
 
 #define DEBUG 0
+
+int txcap=0;  //RLB
+int txcount=0;
+int scount = 0;
+//float avg = 0.0;
+float peak = 0.0;
+float peakavg = 0.0;
+float peaka = 0.0;
+float peaka_avg = 0.0;
+float avgpwr = 0.0;
+float peakpwr = 0.0;
 
 int bandtweak = 4;		// Band power array index the \bs command will target -n1qm
 int ext_ptt_enable = 0; // ADDED BY KF7YDU.
@@ -1146,6 +1156,22 @@ void rx_linear(int32_t *input_rx, int32_t *input_mic,
 {
 	int i = 0;
 	double i_sample;
+	
+	if (txcap == 1) {  //  RLB
+		txcap=0;
+		peakavg = peakavg/scount;
+		peaka_avg = peaka_avg/scount;
+		avgpwr = avgpwr/txcount;
+		printf(" peak %f peaka %f peakavg %f peaka_avg %f avgpwr %.1f peakpwr %.1f count %d\n",peak, peaka,  peakavg, peaka_avg, avgpwr/10, peakpwr/10, txcount);
+		peak = 0.0;
+		peakavg = 0.0;
+		peaka = 0.0;
+		peaka_avg =0.0;
+		txcount = 0;
+		scount = 0;
+		avgpwr = 0.0;
+		peakpwr = 0.0;
+	}
 
 	// STEP 1: First add the previous M samples
 	// memcpy to replace for loop, ffts are 16 bytes
@@ -1561,6 +1587,10 @@ void read_power()
 	// Implement a simple "hold" algorithm in order to show
 	// readable and meaningful power readings that should be the pep power
 	fwdpw = (fwdvoltage * fwdvoltage) / 400;
+	
+	avgpwr +=  fwdpw;  //       RLB
+	if (fwdpw > peakpwr) peakpwr = fwdpw;
+	
 	if (fwdpw > fwdpower_calc) {
 		fwdpower_calc = fwdpw;
 	}
@@ -1596,6 +1626,9 @@ void tx_process(
 {
 	int i;
 	double i_sample, q_sample, i_carrier;
+	
+	if (txcap == 0) txcap = 1;  // RLB
+	txcount++;
 
 	// Check if browser microphone is active and use it instead of physical mic
 	int32_t browser_mic_samples[n_samples];
@@ -1724,6 +1757,10 @@ void tx_process(
 				i_sample = (1.0 * input_mic[j]) / 2000000000.0;
 			}
 		}
+		
+		scount++;
+		peakavg += fabs(i_sample);     // RLB
+		if (fabs(i_sample) > peak) peak = i_sample;		
 
 		// clip the overdrive to prevent damage up the processing chain, PA
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM)
@@ -1737,6 +1774,9 @@ void tx_process(
 			else if (i_sample > voice_clip_level)
 				i_sample = voice_clip_level;
 		}
+		
+		if (fabs(i_sample) > peaka) peaka = fabs(i_sample);   // RLB
+		peaka_avg += fabs(i_sample);
 
 		// Don't echo the voice modes
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM || r->mode == MODE_NBFM)

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -116,7 +116,7 @@ static int rx_pitch = 700; // used only to offset the lo for CW,CWR
 static int bridge_compensation = 100;
 static double voice_clip_level = 0.04;
 static int in_calibration = 1; // this turns off alc, clipping et al
-static double ssb_val = 1.0;   // W9JES
+static double mode_bal = 1.0;   // RLB
 int dsp_enabled = 0;		   // dsp W2JON
 int anr_enabled = 0;		   // anr W2JON
 int notch_enabled = 0;		   // notch filter W2JON
@@ -1849,12 +1849,6 @@ void tx_process(
 			__real__ fft_out[i] = 0;
 			__imag__ fft_out[i] = 0;
 		}
-	// adjust USB/CW modulation power factor W9JES
-	for (i = 0; i < MAX_BINS / 2; i++)
-	{
-		__real__ fft_out[i] = __real__ fft_out[i] * ssb_val;
-		__imag__ fft_out[i] = __imag__ fft_out[i] * ssb_val;
-	}
 
 	// now rotate to the tx_bin
 	// rememeber the AM is already a carrier modulated at 24 KHz
@@ -1878,16 +1872,22 @@ void tx_process(
 	fftw_execute(r->plan_rev);
 	int min = 10000000;
 	int max = -10000000;
-	float scale = volume;
+	float tx_mode_scale = 1.0;
+	float scale = 1.0;
+	
+	if (r->mode == MODE_LSB || r->mode == MODE_CWR) // RLB balance modes here
+		tx_mode_scale = mode_bal; 
+	scale = volume * tx_amp * alc_level * tx_mode_scale; // combine all scale factors
 	for (i = 0; i < MAX_BINS / 2; i++)
 	{
 		double s = creal(r->fft_time[i + (MAX_BINS / 2)]);
-		output_tx[i] = s * scale * tx_amp * alc_level;
-		if (min > output_tx[i])
+		output_tx[i] = s * scale;
+/*		if (min > output_tx[i])
 			min = output_tx[i];
 		if (max < output_tx[i])
 			max = output_tx[i];
-		// output_tx[i] = 0;
+		 output_tx[i] = 0;
+*/
 	}
 	//	printf("min %d, max %d\n", min, max);
 
@@ -2110,8 +2110,8 @@ static int hw_settings_handler(void *user, const char *section,
 	if (!strcmp(name, "bfo_freq"))
 		bfo_freq = atoi(value);
 	// Add variable for SSB/CW Power Factor Adjustment W9JES
-	if (!strcmp(name, "ssb_val"))
-		ssb_val = atof(value);
+	if (!strcmp(name, "mode_bal"))
+		mode_bal = atof(value);
 	// Add TCXO Calibration W9JES/KK4DAS
 	if (!strcmp(section, "tcxo"))
 	{
@@ -2376,11 +2376,11 @@ void setup()
 
 	modem_init();
 
-	add_rx(7000000, MODE_LSB, -3000, -300);
-	add_tx(7000000, MODE_LSB, -3000, -300);
+	add_rx(7000000, MODE_LSB, -3000, -200);  // RLB made all edges 200
+	add_tx(7000000, MODE_LSB, -3000, -200);
 	rx_list->tuned_bin = 512;
 	tx_list->tuned_bin = 512;
-	tx_init(7000000, MODE_LSB, -3000, -150);
+	tx_init(7000000, MODE_LSB, -3000, -200);
 
 	// detect the version of sbitx
 	uint8_t response[4];
@@ -2478,24 +2478,24 @@ void sdr_request(char *request, char *response)
 		else if (rx_list->mode == MODE_LSB || rx_list->mode == MODE_CWR)
 		{
 			// puts("\n\n\ntx LSB filter ");
-			filter_tune(tx_list->filter,
+			filter_tune(tx_list->filter,  // RLB set all edges to 200
 						(1.0 * -3500) / 96000.0,
-						(1.0 * -100) / 96000.0,
+						(1.0 * -200) / 96000.0,
 						5);
 			filter_tune(tx_filter,
 						(1.0 * -3500) / 96000.0,
-						(1.0 * -100) / 96000.0,
+						(1.0 * -200) / 96000.0,
 						5);
 		}
 		else
 		{
 			// puts("\n\n\ntx USB filter ");
 			filter_tune(tx_list->filter,
-						(1.0 * 300) / 96000.0,
+						(1.0 * 200) / 96000.0,
 						(1.0 * 3500) / 96000.0,
 						5);
 			filter_tune(tx_filter,
-						(1.0 * 300) / 96000.0,
+						(1.0 * 200) / 96000.0,
 						(1.0 * 3500) / 96000.0,
 						5);
 		}
@@ -2514,10 +2514,10 @@ void sdr_request(char *request, char *response)
 	else if (!strcmp(cmd, "txmode"))
 	{
 		puts("\n\n\n\n###### tx filter #######");
-		if (!strcmp(value, "LSB") || !strcmp(value, "CWR"))
-			filter_tune(tx_filter, (1.0 * -3000) / 96000.0, (1.0 * -300) / 96000.0, 5);
+		if (!strcmp(value, "LSB") || !strcmp(value, "CWR"))  // RLB changed to 200
+			filter_tune(tx_filter, (1.0 * -3000) / 96000.0, (1.0 * -200) / 96000.0, 5);
 		else
-			filter_tune(tx_filter, (1.0 * 300) / 96000.0, (1.0 * 3000) / 96000.0, 5);
+			filter_tune(tx_filter, (1.0 * 200) / 96000.0, (1.0 * 3000) / 96000.0, 5);
 	}
 	else if (!strcmp(cmd, "record"))
 	{

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -26,17 +26,6 @@
 
 #define DEBUG 0
 
-int txcap=0;  //RLB
-int txcount=0;
-int scount = 0;
-//float avg = 0.0;
-float peak = 0.0;
-float peakavg = 0.0;
-float peaka = 0.0;
-float peaka_avg = 0.0;
-float avgpwr = 0.0;
-float peakpwr = 0.0;
-
 int bandtweak = 4;		// Band power array index the \bs command will target -n1qm
 int ext_ptt_enable = 0; // ADDED BY KF7YDU.
 char audio_card[32];
@@ -1156,23 +1145,6 @@ void rx_linear(int32_t *input_rx, int32_t *input_mic,
 {
 	int i = 0;
 	double i_sample;
-	
-	if (txcap == 1) {  //  RLB
-		txcap=0;
-		peakavg = peakavg/scount;
-		peaka_avg = peaka_avg/scount;
-		avgpwr = avgpwr/txcount;
-		printf(" peak %f peaka %f peakavg %f peaka_avg %f avgpwr %.1f peakpwr %.1f count %d\n",peak, peaka,  peakavg, peaka_avg, avgpwr/10, peakpwr/10, txcount);
-		peak = 0.0;
-		peakavg = 0.0;
-		peaka = 0.0;
-		peaka_avg =0.0;
-		txcount = 0;
-		scount = 0;
-		avgpwr = 0.0;
-		peakpwr = 0.0;
-	}
-
 	// STEP 1: First add the previous M samples
 	// memcpy to replace for loop, ffts are 16 bytes
 	memcpy(fft_in, fft_m, MAX_BINS / 2 * 8 * 2);
@@ -1588,9 +1560,6 @@ void read_power()
 	// readable and meaningful power readings that should be the pep power
 	fwdpw = (fwdvoltage * fwdvoltage) / 400;
 	
-	avgpwr +=  fwdpw;  //       RLB
-	if (fwdpw > peakpwr) peakpwr = fwdpw;
-	
 	if (fwdpw > fwdpower_calc) {
 		fwdpower_calc = fwdpw;
 	}
@@ -1626,10 +1595,6 @@ void tx_process(
 {
 	int i;
 	double i_sample, q_sample, i_carrier;
-	
-	if (txcap == 0) txcap = 1;  // RLB
-	txcount++;
-
 	// Check if browser microphone is active and use it instead of physical mic
 	int32_t browser_mic_samples[n_samples];
 	int use_browser_mic = is_browser_mic_active();
@@ -1757,10 +1722,6 @@ void tx_process(
 				i_sample = (1.0 * input_mic[j]) / 2000000000.0;
 			}
 		}
-		
-		scount++;
-		peakavg += fabs(i_sample);     // RLB
-		if (fabs(i_sample) > peak) peak = i_sample;		
 
 		// clip the overdrive to prevent damage up the processing chain, PA
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM)
@@ -1774,9 +1735,6 @@ void tx_process(
 			else if (i_sample > voice_clip_level)
 				i_sample = voice_clip_level;
 		}
-		
-		if (fabs(i_sample) > peaka) peaka = fabs(i_sample);   // RLB
-		peaka_avg += fabs(i_sample);
 
 		// Don't echo the voice modes
 		if (r->mode == MODE_USB || r->mode == MODE_LSB || r->mode == MODE_AM || r->mode == MODE_NBFM)


### PR DESCRIPTION
Redid mode balancing to use one factor called mode_bal to bring LSB and CWR down to about the same power levels (small difference between the two). mode_bal read from hw_settings.ini. Defaults to 1.0. 0.8 works well for V2.
Balancing now done at last step in output_tx loop.
SSB modes tx filers had lower edges varying from 100 to 300 - changed all to 200.
Release notes updated