### PR TITLE
Gridmap fix

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -51,7 +51,9 @@
 	+ Replaced viterbi with simpler classifier
 	+ Simplified code of own TX decode process
 	+ Set BW to `50` when using decoder is recommended
-- Added more controls to the Web interface
+- Web interface
+  + Added more controls
+  + Gridmap new options: Square or round Grid dots; Seen Grids; Unlogged Grids;
   
 **Fixes:**
 - APF init Bug
@@ -60,8 +62,10 @@
 	+ Made a small change to cleanup the static between TX to RX 
 - APM sampling improved for better regularity
 - VSWR initialization when user disabled fixed
+- max_vswr=0 now restored as no max vswr protection at startup
 - Fixed scope intensity where it now loads and restores previous setting
 - Fixed Macro loading and F1-F8 buttons when changing modes
+- Web Gridmap red Grid dots now shown when QSO is logged
 
 # v5.301
 **Bug Fixes:**

--- a/src/hist_disp.c
+++ b/src/hist_disp.c
@@ -81,8 +81,9 @@ char ff_char(int style) {
 			return 'A' + 17;
 		case STYLE_CALLEE:
 		case STYLE_RECENT_CALLER:
+		    return 'A' + 5;
 		case STYLE_EXISTING_GRID:
-			return 'A' + 5;
+			return 'A' + 22;
 		case STYLE_GRID:
 			return 'A' + 18;
 		case STYLE_TIME:

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -2662,7 +2662,11 @@ static int user_settings_handler(void *user, const char *section,
 		{
 			/* allow float values; 0 or negative => disabled */
 			max_vswr = atof(value);
-			if (max_vswr < 0.1f) vswr=0;
+			if (max_vswr < 0.1f) 
+            {           
+              vswr=0;
+              vswr_on = 0;  // turn off protection
+            }
 			return 1;
 		}
 

--- a/web/gridmap.js
+++ b/web/gridmap.js
@@ -28,8 +28,8 @@ const GRIDMAP = (function gridmap() {
   img.crossOrigin = "anonymous";
   img.src = "./Web_maps_Mercator_projection_SW.jpg";
 
-  const kx = projection.forward([180, 0])[0]; // x-coordinate at (180°, 0°) in meters
-  const ky = projection.forward([0, 85])[1];  // y-coordinate at (0°, 85°) in meters
+  const kx = projection.forward([180, 0])[0]; // x-coordinate at (180ï¿½, 0ï¿½) in meters
+  const ky = projection.forward([0, 85])[1];  // y-coordinate at (0ï¿½, 85ï¿½) in meters
 
   const scaleMin = 25;
   const scaleMax = 200;
@@ -44,9 +44,15 @@ const GRIDMAP = (function gridmap() {
   const gridsSeenLogged = new Set();
   const gridsSeenNotLogged = new Set();
   const gridsSeenJustLogged = new Set();
-  let showGridsSeen = true;
+  let showGridsSeen = false;
+  let showGridsUnlogged = true;
+ 
+  const btnGridsUnLogged = document.createElement("button");
 
-  var viewOffsetX = 0; // Tracks panning offset (replaces scrollLeft)
+  const btnShowRoundDots = document.createElement("button");
+  var use_square_dots = true;
+  
+  var viewOffsetX = 0; // Tracks panning offset (replaces scrollLeft)  
   var viewOffsetY = 0; // Tracks panning offset (replaces scrollTop)
 
   function setToolTip(elt, tip) {
@@ -62,6 +68,10 @@ const GRIDMAP = (function gridmap() {
     btnGridsSeen.enabled = b;
     btnGridsLogged.className = showGridsLogged ? "gm_btn_on" : "gm_btn_off";
     btnGridsLogged.enabled = b;
+    btnGridsUnLogged.className = showGridsUnlogged ? "gm_btn_on" : "gm_btn_off";
+    btnGridsUnLogged.enabled = b;
+    btnShowRoundDots.className = use_square_dots ? "gm_btn_off" : "gm_btn_on";
+    btnShowRoundDots.enabled = b;
   }
 
   function gmBuildHtml() {
@@ -80,23 +90,31 @@ const GRIDMAP = (function gridmap() {
 
     zoomSpan.style = "width: 45px; display: inline-flex;";
     const sliderDiv = document.createElement("div");
+    btnShowRoundDots.innerText = "Round";
+    btnShowRoundDots.title = "Show big round dots";
+    sliderDiv.appendChild(btnShowRoundDots);
     slider.type = "range";
     slider.min = scaleMin;
     slider.max = scaleMax;
     slider.value = scaleCur; // Reflects initial scaleCur = 30
     slider.step = scaleStep;
     slider.id = "gridzoom";
-    slider.style = "width: 150px;";
+    slider.style = "width: 120px;";
     sliderDiv.appendChild(zoomSpan);
     sliderDiv.appendChild(slider);
     btnGridsLogged.innerText = "Logged";
+    btnGridsLogged.title = "Show all logged grids";
     sliderDiv.appendChild(btnGridsLogged);
     btnGridsSeen.innerText = "Seen";
+    btnGridsSeen.title = "Show all grids seen during this session";
     sliderDiv.appendChild(btnGridsSeen);
+    btnGridsUnLogged.innerText ="Unlogged";
+    btnGridsUnLogged.title = "Show all unlogged grids seen during this session";
+    sliderDiv.appendChild(btnGridsUnLogged);
     setBtnsStateEnable(false);
     sliderDiv.appendChild(infoDiv);
     infoDiv.appendChild(infoSpan);
-    infoSpan.style = "width: 200px; text-align: center; display: inline-flex;";
+    infoSpan.style = "font-size: 12px; width: 120px; text-align: center; display: inline-flex;";
     setToolTip(infoDiv, "(longitude,latitude) GridId");
     containerDiv.appendChild(canvasDiv);
     containerDiv.appendChild(sliderDiv);
@@ -175,7 +193,7 @@ const GRIDMAP = (function gridmap() {
     if (gmIsValidGridId(gridId)) {
       point[0] = (gridId.charCodeAt(0) - 'A'.charCodeAt(0)) * 10 + (gridId.charCodeAt(2) - '0'.charCodeAt(0));
       point[1] = (gridId.charCodeAt(1) - 'A'.charCodeAt(0)) * 10 + (gridId.charCodeAt(3) - '0'.charCodeAt(0));
-    }
+    }                          
     return point;
   }
 
@@ -197,19 +215,32 @@ const GRIDMAP = (function gridmap() {
   // Replace gmSetGridMark:
   function gmSetGridMark(col, row, clr) {
     const f = 150.0;
-    const sx = Math.round(ofsCanvas.width / f);
-    const sy = Math.round(ofsCanvas.height / f);
-    const radius = Math.min(sx, sy) / 2; // Radius for circles
-
     const longitude = col * 2 - 180 + 0.0;
     const latitude = row - 90 + 1.0;
 
     const point = gmToMercatorPoint(longitude, latitude);
-
-    ofsCtx.fillStyle = clr;
-    ofsCtx.beginPath();
-    ofsCtx.arc(point[0] + radius, point[1] + radius, radius, 0, 2 * Math.PI);
-    ofsCtx.fill();
+    
+    if (use_square_dots) {
+      // const sx = Math.round(ofsCanvas.width / f);
+      const sy = Math.round(ofsCanvas.height / f);
+      // const oldMode = ofsCtx.globalCompositeOperation;
+      // ofsCtx.globalCompositeOperation = 'difference';
+      ofsCtx.fillStyle = "PowderBlue";
+      ofsCtx.fillRect(point[0], point[1], sy/2+1, sy/2+1);
+      // ofsCtx.globalCompositeOperation = oldMode;
+      ofsCtx.fillStyle = clr;
+      ofsCtx.fillRect(point[0]+1, point[1]+1, sy/2-1, sy/2-1);
+    }
+    else {
+      const sx = Math.round(ofsCanvas.width / f);
+      const sy = Math.round(ofsCanvas.height / f);
+      const radius = Math.min(sx, sy) / 2; // Radius for circles
+      ofsCtx.fillStyle = clr;
+      ofsCtx.beginPath();
+      ofsCtx.arc(point[0] + radius, point[1] + radius, radius, 0, 2 * Math.PI);
+      ofsCtx.fill();
+    }    
+    
   }
   function gmShowGridId(gridId, clr) {
     const point = gmGridIdToPoint(gridId);
@@ -336,7 +367,7 @@ const GRIDMAP = (function gridmap() {
 
   function gmGridIdNotLogged(gridId) {
     gridsSeenNotLogged.add(gridId);
-    if (showGridsSeen) {
+    if (showGridsUnlogged) {
       gmShowGridId(gridId, "rgb(247, 247, 38)");
       gmDelayedRefresh();
     }
@@ -351,6 +382,12 @@ const GRIDMAP = (function gridmap() {
     }
   }
 
+  function clickShowRoundDots() {
+    use_square_dots = !use_square_dots;
+    setBtnsStateEnable(false);
+    reloadGridMap();
+  }
+
   function clickGridsLogged() {
     showGridsLogged = !showGridsLogged;
     setBtnsStateEnable(false);
@@ -359,6 +396,15 @@ const GRIDMAP = (function gridmap() {
 
   function clickGridsSeen() {
     showGridsSeen = !showGridsSeen;
+    if(showGridsSeen) {
+      showGridsUnlogged = true;
+    }
+    setBtnsStateEnable(false);
+    reloadGridMap();
+  }
+
+  function clickGridsUnlogged() {
+    showGridsUnlogged = !showGridsUnlogged;
     setBtnsStateEnable(false);
     reloadGridMap();
   }
@@ -368,7 +414,14 @@ const GRIDMAP = (function gridmap() {
     for (const gridId of setIterator) {
       gmShowGridId(gridId[0], "darkgreen");
     }
-    setIterator = gridsSeenNotLogged.entries();
+    setIterator = gridsSeenJustLogged.entries();
+    for (const gridId of setIterator) {
+      gmShowGridId(gridId[0], "red");
+    }
+  }
+
+  function gmMarkUnloggedGridIds() {
+    let setIterator = gridsSeenNotLogged.entries();
     for (const gridId of setIterator) {
       gmShowGridId(gridId[0], "rgb(250, 250, 38)");
     }
@@ -399,24 +452,29 @@ const GRIDMAP = (function gridmap() {
     }
   }
 
-  function reloadGridMap() {
+  function reloadGridMap(do_center) {
     ofsCanvas.width = img.width;
     ofsCanvas.height = img.height;
     ofsCtx.drawImage(img, 0, 0);
     img.style.display = "none";
     console.log(`Map dimensions: ${img.width}x${img.height}`); // Debug
 
-    // Center map horizontally at 30% scale
-    const fScale = scaleCur / 100; 
-    const scaledWidth = ofsCanvas.width * fScale;
-    viewOffsetX = (scaledWidth - fixedWidth) / 2; // Center horizontally
-    viewOffsetY = 0; // Top-aligned, as in original
+    if (do_center) {
+      // Center map horizontally at 30% scale
+      const fScale = scaleCur / 100; 
+      const scaledWidth = ofsCanvas.width * fScale;
+      viewOffsetX = (scaledWidth - fixedWidth) / 2; // Center horizontally
+      viewOffsetY = 0; // Top-aligned, as in original
+    }
 
     if (showGridsLogged) {
       gmMarkLoggedGridIds();
     }
     if (showGridsSeen) {
       gmMarkSeenGridIds();
+    }
+    if (showGridsUnlogged) {
+      gmMarkUnloggedGridIds();
     }
     gmDrawScaledCanvas(scaleCur);
     setBtnsStateEnable(true);
@@ -438,7 +496,7 @@ const GRIDMAP = (function gridmap() {
       }
       gridIdsLoaded = true;
       if (worldMapLoaded) {
-        reloadGridMap();
+        reloadGridMap(true);
       }
     });
   }
@@ -447,13 +505,15 @@ const GRIDMAP = (function gridmap() {
   img.addEventListener("load", () => {
     worldMapLoaded = true;
     if (gridIdsLoaded) {
-      reloadGridMap();
+      reloadGridMap(true);
     }
   });
 
+  btnShowRoundDots.addEventListener("click", clickShowRoundDots);
   slider.addEventListener('change', gmSliderZoom, false);
   btnGridsLogged.addEventListener("click", clickGridsLogged);
   btnGridsSeen.addEventListener("click", clickGridsSeen);
+  btnGridsUnLogged.addEventListener("click", clickGridsUnlogged);
   canvasDiv.addEventListener("wheel", gmMouseZoom, { passive: false });
   canvasDiv.addEventListener("mousemove", (event) => gmMouseMove(event));
   canvasDiv.addEventListener("mousedown", (event) => gmPick(event));

--- a/web/index.html
+++ b/web/index.html
@@ -3352,6 +3352,7 @@
 	const STYLE_LOG = 'F'; // generic; also several FTX-specific fields
 	const STYLE_MYCALL = 'Q';
 	const STYLE_CALLER = 'R';
+	const STYLE_EXISTING_GRID = 'W';
 	const STYLE_GRID = 'S';
 	const STYLE_DISTANCE = 'U';
 	const STYLE_AZIMUTH = 'V';
@@ -3383,17 +3384,21 @@
 			case STYLE_CALLER:
 				jclass = "ftx-caller";
 				break;
-			case STYLE_GRID:
+            case STYLE_EXISTING_GRID:
 				jclass = "ftx-grid";
+				GRIDMAP.gridIdLogged(text.substring(2));
+				break;
+			case STYLE_GRID:
+				jclass = "ftx-grid-not-logged";
 				GRIDMAP.gridIdNotLogged(text.substring(2));
 				break;
 			case STYLE_DISTANCE:
 				jclass = "ftx-distance";
-				GRIDMAP.gridIdNotLogged(text.substring(2));
+				//GRIDMAP.gridIdNotLogged(text.substring(2));
 				break;
 			case STYLE_AZIMUTH:
 				jclass = "ftx-azimuth";
-				GRIDMAP.gridIdNotLogged(text.substring(2));
+				//GRIDMAP.gridIdNotLogged(text.substring(2));
 				break;
 			case STYLE_FTX_QUEUED:
 				jclass = "ftx-queued";
@@ -4062,11 +4067,12 @@
             var data = xml.getElementsByTagName("LOG");
             for (var i = 0; i < data.length; i++) {
                 let s = data[i].innerHTML;
-                write_console(s);
+                console_update(s);  // write_console(s);
                 // Extract qso grid from message e.g.
-                // "Logged: F4VTG -05-JO65 -14-JN12\n;"
-                if (s.startsWith("Logged:")) { // String ends width \n
-                    s = s.substring(s.length - 5, s.length - 1);
+                // "Logged: UR3HC KN69 s -10 r -12 pwr 0.9 swr 1.3\n"
+                if (s.startsWith("Logged:")) {
+                    const fields = s.split(" ");
+                    s = fields[2] || "";
                     GRIDMAP.gridIdJustLogged(s);
                 }
             }

--- a/web/style.css
+++ b/web/style.css
@@ -567,6 +567,11 @@ input {
 
 .ftx-grid {
 	font-weight: bold;
+    color: rgba(0, 255, 162, 0.495);
+}
+
+.ftx-grid-not-logged {
+	font-weight: bold;
     color: rgb(255, 204, 0);
 }
 


### PR DESCRIPTION
The 1. commit "settings load max_vswr=0 fix" is not related to gridmap. It fixes the error that causes a max_vsvr=0 value (that indicates no max vswr protection)  to be restored incorrectly. The code has another variable vswr_on that must be set to 0 in order for the protection to be off. 
I had the problem that my 100W PA caused the sBitx to detect high SWR (for a short period) - so I had to turn the protection off. Unfortunately the protection was on again after sBitx restart.

The 2. commit "gridmap fix and dot choice" restores the features that I miss in the current version.
The map is fine as is.  I want to see if I have covered all grids in an area, but the round dots are to big and overlaps for this purpose.  I have replaced them with smaller square dots- with round dots as an option.  
The feature where you can see the  all grids appearing as they are seen is back - as an  option.  Also as an option (on by default) the seen grids can be limited to the unlogged ones shown in yellow.
Just click the buttons and you will understand how they works. 
I also fixed an error so just completed QSO's again are shown as red dots.

![Screenshot 2026-04-07 005905](https://github.com/user-attachments/assets/34c3592b-0dee-4d8b-b0fd-68c78b260788)

