### PR TITLE
Power limit

### DIFF
--- a/gsw power_limit
+++ b/gsw power_limit
@@ -1,0 +1,24 @@
+  alc[m
+  alc_limits[m
+  allband_alc[m
+* [32mdev[m
+  main[m
+  power[m
+  power_limit[m
+  rebalance[m
+  [31mremotes/origin/APM1[m
+  [31mremotes/origin/APM2[m
+  [31mremotes/origin/HEAD[m -> origin/main
+  [31mremotes/origin/SWR[m
+  [31mremotes/origin/VUmeter[m
+  [31mremotes/origin/alc[m
+  [31mremotes/origin/alc_limits[m
+  [31mremotes/origin/allband_alc[m
+  [31mremotes/origin/balance[m
+  [31mremotes/origin/dev[m
+  [31mremotes/origin/levels[m
+  [31mremotes/origin/main[m
+  [31mremotes/origin/power[m
+  [31mremotes/origin/power_limit[m
+  [31mremotes/origin/rebalance[m
+  [31mremotes/origin/test[m

--- a/release_notes.md
+++ b/release_notes.md
@@ -35,6 +35,10 @@
     + Shows color strips or shading for bands edges and US license class
 	+ Each file can be customized outside the USA
 	+ More details and instructions in the oob_limits files in the data folder
+ - Added ALC power limits by band, if RF power exceeds limit it is folded back to limit
+ 	+ Default is off until a limit is set in hw_settings.ini by adding line max_watts=nn to band data after f_stop
+	+ When activated message is given in spectrum between Power and VSWR
+  	+ Power reduction is released when RF power drops below bamd limit 
 
 **Changes:**
 - GUI
@@ -54,6 +58,9 @@
 - Web interface
   + Added more controls
   + Gridmap new options: Square or round Grid dots; Seen Grids; Unlogged Grids;
+- Power and VSWR readings updated 10 more often, from every second to every 100 ms
+  + Updates are now as fast as bridge reads allow
+- Minimum power for VSWR calculation increased to help eliminate invalid reads at very low powers
   
 **Fixes:**
 - APF init Bug

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -176,10 +176,9 @@ FILE *pf_debug = NULL;
 //#define ADC_SCALE  400000000.0
 #define ADC_SCALE  200000000.0
 
-int sbitx_version = SBITX_V2;
-int fwdpower, vswr;
-int fwdpower_calc;
-int fwdpower_cnt;
+int sbitx_version = SBITX_V2;  // never used
+int fwdpower = 0;
+int vswr = 10;
 
 float fft_bins[MAX_BINS]; // spectrum ampltiudes
 float spectrum_window[MAX_BINS];
@@ -227,13 +226,14 @@ struct rx *rx_list = NULL;
 struct rx *tx_list = NULL;
 struct filter *tx_filter; // convolution filter
 static double tx_amp = 0.0;
-static double alc_level = 1.0;
+float alc_level = 1.0;
 static int tr_relay = 0;
 static int rx_pitch = 700; // used only to offset the lo for CW,CWR
 static int bridge_compensation = 100;
 static double voice_clip_level = 0.04;
 static int in_calibration = 1; // this turns off alc, clipping et al
 static double mode_bal = 1.0;   // RLB
+float allband_max = 41.7;  // RLB
 int dsp_enabled = 0;		   // dsp W2JON
 int anr_enabled = 0;		   // anr W2JON
 int notch_enabled = 0;		   // notch filter W2JON
@@ -1796,63 +1796,67 @@ void read_power()
 {
 	uint8_t response[4];
 	int16_t vfwd, vref;
-	int fwdpw;
-
-	char buff[20];
+	float fwdpw;
+	static int last_vfwd = 0;  // check for change
 
 	if (!in_tx)
 		return;
 	if (i2cbb_read_i2c_block_data(0x8, 0, 4, response) == -1)
 		return;
 
-	vfwd = vref = 0;
-
-	memcpy(&vfwd, response, 2);
+	vfwd = vref = 0;  
+	memcpy(&vfwd, response, 2);  // bridge voltage values 0-1023
 	memcpy(&vref, response + 2, 2);
-	//	printf("%d:%d\n", vfwd, vref);
-
+	
+	if ( vfwd == last_vfwd) {
+		return;  // no change so do nothing	
+	}
+	last_vfwd = vfwd;
+	
+	if (vfwd < 20 ) {  // approx 0, clean up drop to zero power while still in transmit
+		fwdpower = 0;  // Immediate zeroing smmothed power 
+		vswr = 10;
+		alc_level=1.0;
+		return;
+	}
+	
 	// Very low power readings may spoil the swr calculation, especially in CW modes between symbols
 	// Better not to calculate the swr at all if the measured power is under a very minimal level
-	if (vfwd > 3) {
+	// vfwd 0-1023, limit changed from 3 to 50 ~.1 watt   RLB
+	vswr=10;  // farham x10 integers
+	if (vfwd > 50) {   // don't calculate if < .1 watt
 		if (vref >= vfwd)
 			vswr = 100;
 		else
-			vswr = (10 * (vfwd + vref)) / (vfwd - vref);
+			vswr = round((10 * (vfwd + vref)) / (vfwd - vref));
 	}
 
 	// here '400' is the scaling factor as our ref power output is 40 watts
 	// this calculates the power as 1/10th of a watt, 400 = 40 watts
-	int fwdvoltage = (vfwd * 40) / bridge_compensation;
+	float fwdvoltage = (vfwd * 40.0) / bridge_compensation;
+	fwdpw = (fwdvoltage * fwdvoltage) / 400.0;
+	// replace report once per 100 ticks (~1 s) with every vfrd update (~100 ms) RLB
+	if ( fwdpower > 0 ) {  // fwdpower is displayed power, expoential smoothing a=.5 
+	fwdpower = round((5.0*fwdpw + 5*fwdpower)/10.0);  
+	}	else  {
+		fwdpower = round(fwdpw);  // start history
+	}
 
-	// Implement a simple "hold" algorithm in order to show
-	// readable and meaningful power readings that should be the pep power
-	fwdpw = (fwdvoltage * fwdvoltage) / 400;
+	float cpower;
+	cpower=(float)fwdpower/10.0;
 	
-	if (fwdpw > fwdpower_calc) {
-		fwdpower_calc = fwdpw;
+	if (cpower > allband_max) {   // check power  against allband_max
+		alc_level = alc_level * allband_max/cpower; // scale alc_limit
+		return;
 	}
-	if (!fwdpower_cnt) {
-		fwdpower = fwdpower_calc;
-		fwdpower_calc = fwdpw;
+	
+	if (alc_level < 1.0 ) {  // restore alc_level
+		alc_level = alc_level + (1.0-alc_level)/2.0;
 	}
-	if (!fwdpower)
-		fwdpower = fwdpw;
-	fwdpower_cnt = ++fwdpower_cnt % 100;
-
-	int rf_v_p2p = (fwdvoltage * 126) / 400;
-	//	printf("rf volts: %d, alc %g, %d watts ", rf_v_p2p, alc_level, fwdpower/10);
-	if (rf_v_p2p > 135 && !in_calibration)
-	{
-		alc_level *= 135.0 / (1.0 * rf_v_p2p);
-		printf("ALC tripped, to %d percent\n", (int)(100 * alc_level));
-	}
-	/*	else if (alc_level < 0.95){
-			printf("alc releasing to ");
-			alc_level *= 1.02;
-		}
-	*/
-	//	printf("alc: %g\n", alc_level);
+	
+	return;		
 }
+
 
 static int tx_process_restart = 1;
 
@@ -2517,6 +2521,8 @@ static int hw_settings_handler(void *user, const char *section,
 	// Add variable for SSB/CW Power Factor Adjustment W9JES
 	if (!strcmp(name, "mode_bal"))
 		mode_bal = atof(value);
+	if (!strcmp(name, "allband_max"))
+		allband_max = atof(value);
 	// Add TCXO Calibration W9JES/KK4DAS
 	if (!strcmp(section, "tcxo"))
 	{
@@ -2713,9 +2719,9 @@ void tr_switch(int tx_on) {
     }
     digitalWrite(TX_LINE, HIGH);
     spectrum_reset();
-    fwdpower_cnt = 0;
-    fwdpower_calc = 0;
+ 
     fwdpower = 0;
+    alc_level=1.0;
 
   } else {                       // switch to receive
     /* ── T/R relay sequence ─────────────────────────────────────────────
@@ -2766,8 +2772,7 @@ void tr_switch(int tx_on) {
     sound_mixer(audio_card, "Capture", rx_gain);
     spectrum_reset();
 
-    fwdpower_cnt = 0;
-    fwdpower_calc = 0;
+
     fwdpower = 0;
   }
 }

--- a/src/sbitx.c
+++ b/src/sbitx.c
@@ -179,6 +179,7 @@ FILE *pf_debug = NULL;
 int sbitx_version = SBITX_V2;  // never used
 int fwdpower = 0;
 int vswr = 10;
+int cur_band;
 
 float fft_bins[MAX_BINS]; // spectrum ampltiudes
 float spectrum_window[MAX_BINS];
@@ -233,7 +234,6 @@ static int bridge_compensation = 100;
 static double voice_clip_level = 0.04;
 static int in_calibration = 1; // this turns off alc, clipping et al
 static double mode_bal = 1.0;   // RLB
-float allband_max = 41.7;  // RLB
 int dsp_enabled = 0;		   // dsp W2JON
 int anr_enabled = 0;		   // anr W2JON
 int notch_enabled = 0;		   // notch filter W2JON
@@ -305,15 +305,15 @@ struct power_settings
 };
 
 struct power_settings band_power[] = {
-	{3500000, 4000000, 37, 0.002},
-	{5251500, 5360000, 40, 0.0015},
-	{7000000, 7300009, 40, 0.0015},
-	{10000000, 10200000, 35, 0.0019},
-	{14000000, 14300000, 35, 0.0025},
-	{18000000, 18200000, 20, 0.0023},
-	{21000000, 21450000, 20, 0.003},
-	{24800000, 25000000, 20, 0.0034},
-	{28000000, 29700000, 20, 0.0037}};
+	{3500000, 4000000, 0, 0.002},
+	{5251500, 5360000, 0, 0.0015},
+	{7000000, 7300009, 0, 0.0015},
+	{10000000, 10200000, 0, 0.0019},
+	{14000000, 14300000, 0, 0.0025},
+	{18000000, 18200000, 0, 0.0023},
+	{21000000, 21450000, 0, 0.003},
+	{24800000, 25000000, 0, 0.0034},
+	{28000000, 29700000, 0, 0.0037}};
 
 #define CMD_TX (2)
 #define CMD_RX (3)
@@ -1842,14 +1842,15 @@ void read_power()
 		fwdpower = round(fwdpw);  // start history
 	}
 
-	float cpower;
-	cpower=(float)fwdpower/10.0;
-	
-	if (cpower > allband_max) {   // check power  against allband_max
-		alc_level = alc_level * allband_max/cpower; // scale alc_limit
-		return;
-	}
-	
+	float cpower=(float)fwdpw/10.0;;
+	float climit = band_power[cur_band].max_watts;
+
+	if ( climit > 0.1 && in_calibration) {  // check limits
+		if (cpower > climit) {   // check power  against band_max
+			alc_level = alc_level * climit/cpower; // scale alc_limit
+			return;
+		}
+	}	
 	if (alc_level < 1.0 ) {  // restore alc_level
 		alc_level = alc_level + (1.0-alc_level)/2.0;
 	}
@@ -2513,7 +2514,9 @@ static int hw_settings_handler(void *user, const char *section,
 	if (!strcmp(name, "f_start"))
 		band_power[hw_init_index].f_start = atoi(value);
 	if (!strcmp(name, "f_stop"))
-		band_power[hw_init_index].f_stop = atoi(value);
+		band_power[hw_init_index].f_stop = atoi(value);	
+	if (!strcmp(name, "max_watts"))
+		band_power[hw_init_index].max_watts = atof(value);
 	if (!strcmp(name, "scale"))
 		band_power[hw_init_index++].scale = atof(value);
 	if (!strcmp(name, "bfo_freq"))
@@ -2521,8 +2524,6 @@ static int hw_settings_handler(void *user, const char *section,
 	// Add variable for SSB/CW Power Factor Adjustment W9JES
 	if (!strcmp(name, "mode_bal"))
 		mode_bal = atof(value);
-	if (!strcmp(name, "allband_max"))
-		allband_max = atof(value);
 	// Add TCXO Calibration W9JES/KK4DAS
 	if (!strcmp(section, "tcxo"))
 	{

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -69,6 +69,7 @@ extern char *cw_get_stats(char *buf, size_t len);
 /* VSWR trip flag Clear on band change so previous trips don't persist. */
 extern int vswr_tripped;
 extern float alc_level;
+extern int cur_band;
 extern float vmax; // vlevel meter, now with log voltage levels - not power
 float vlevels[12]= {.1, .126, .158, .2, .25, .316, .398, .5, .631, .794, 1.0, 1.26};
 void change_band(char *request);
@@ -5711,6 +5712,7 @@ struct band *get_band_by_frequency(int frequency)
 		// Use the start and stop fields to define the band edges
 		if (frequency >= band_stack[i].start && frequency <= band_stack[i].stop)
 		{
+			cur_band = i;  // save band for ALC
 			return &band_stack[i]; // Return a pointer to the matching band
 		}
 	}

--- a/src/sbitx_gtk.c
+++ b/src/sbitx_gtk.c
@@ -68,6 +68,7 @@ extern struct rx *rx_list;
 extern char *cw_get_stats(char *buf, size_t len);
 /* VSWR trip flag Clear on band change so previous trips don't persist. */
 extern int vswr_tripped;
+extern float alc_level;
 extern float vmax; // vlevel meter, now with log voltage levels - not power
 float vlevels[12]= {.1, .126, .158, .2, .25, .316, .398, .5, .631, .794, 1.0, 1.26};
 void change_band(char *request);
@@ -83,7 +84,6 @@ int input_volume = 0;
 int vfo_lock_enabled = 0;
 int has_ina260 = 0;
 int freq_out_of_band = 0;  // Set when VFO frequency is outside all band ranges
-
 // ---------------------------------------------------------------------------
 // OOB (out-of-band) privilege limits loaded from ~/sbitx/data/oob_limits.txt
 // ---------------------------------------------------------------------------
@@ -3375,6 +3375,10 @@ void draw_tx_meters(struct field *f, cairo_t *gfx)
 
 	sprintf(meter_str, "Power: %d.%d Watts", power / 10, power % 10);
 	draw_text(gfx, f->x + 20, f->y + 5, meter_str, STYLE_FIELD_LABEL);
+	if (alc_level <.999) {
+		sprintf(meter_str, "ALC");
+		draw_text(gfx, f->x + 140, f->y + 5, meter_str, STYLE_FIELD_LABEL);
+	}		
 	sprintf(meter_str, "VSWR: %d.%d", vswr / 10, vswr % 10);
 	draw_text(gfx, f->x + 200, f->y + 5, meter_str, STYLE_FIELD_LABEL);
 }


### PR DESCRIPTION
Adds per band ALC. Default is off until limits are set in hw_settings.ini band settings with max_watts=nn.
When activated displays message in spectrum.
Automatically releases when RF power is below max_watts
Increased power and VSWR reporting form every about every second (100 ticks) too about 100 ms (~10 ticks)
Raised power required for valid VSWR from about .01 watt to .1 watt
