### PR TITLE
fix SENTRSTCUT macro variable problem

### DIFF
--- a/src/macros.c
+++ b/src/macros.c
@@ -191,7 +191,7 @@ static char *macro_expand_var(char *var, char *s){
 	else if (!strcmp(var, "CALL"))
 		macro_get_var(var, s);
 	else if (!strcmp(var, "SENTRSTCUT"))
-		strcpy(s, "5NN");
+		macro_get_var(var, s);
 	else if (!strcmp(var, "SENTRST"))
 		macro_get_var(var, s);
 	else if (!strcmp(var, "EXCH") || !strcmp(var, "EXCHANGE"))


### PR DESCRIPTION
implements fix reported for problem reported here
https://groups.io/g/BITX20/message/124036

I tested this change on the current 'dev' baseline by editing the cw1.mc file to use SENDRSTCUT, and then trying various RST value in the SENT field.  Completely untested on zbitx (but probably the same)