### PR TITLE
a 'dev-54bugfixes' addition and several optimizations

### DIFF
--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -588,7 +588,7 @@ float cw_tx_get_sample() {
   if ((symbol_now == CW_DOWN) || (symbol_now == CW_DOT) ||
       (symbol_now == CW_DASH) || (symbol_now == CW_SQUEEZE) ||
       (keydown_count > 0))
-    cw_tx_until = millis_now + get_cw_delay();
+    cw_tx_until = millis_now + cw_delay_ms;
   // if macro or keyboard characters remain in the buffer
   // prevent switching from xmit to rcv and cutting off macro
   if (cw_bytes_available != 0)

--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -2038,6 +2038,7 @@ void cw_init(void) {
   keydown_count = 0;
   keyup_count = 0;
   cw_envelope = 0;
+  cw_mode = get_cw_input_method();
 }
 
 // called from sbitx_gtk.c to display cw stats under zerobeat indicator

--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -230,9 +230,10 @@ static const struct morse_rx morse_rx_table[] = {
 
 // global variables
 static unsigned long millis_now = 0;
+static int cw_delay_ms = 300;
 static int cw_key_state = 0;
 static int cw_period;
-static struct vfo cw_tone, cw_env;
+static struct vfo cw_tone;  // cw_env is replaced with data table
 static int keydown_count = 0;
 static int keyup_count = 0;
 static float cw_envelope = 1;
@@ -2032,7 +2033,6 @@ void cw_init(void) {
   // CW TX side (keyer, envelope, LUT)
   cw_init_morse_lut();
   vfo_start(&cw_tone, 700, 0);
-  vfo_start(&cw_env, 200, 49044);  // not used with data-driven waveform
   cw_period = 9600;                // at 96ksps, 0.1 sec = 1 dot at 12 WPM
   keydown_count = 0;
   keyup_count = 0;
@@ -2132,46 +2132,50 @@ char *cw_get_stats(char *buf, size_t len)
 void cw_poll(int bytes_available, int tx_is_on) {
   cw_bytes_available = bytes_available;
   cw_key_state = key_poll();
+  millis_now = millis();
+
+  // cache UI-derived break-in delay here so audio path reads cw_delay_ms only (not the GUI value)
+  cw_delay_ms = get_cw_delay();
+
+  // WPM: recompute period every poll, but only touch the
+  // decoder/tx_decoder state when WPM actually changes ---
   int wpm = field_int("WPM");
   cw_period = (12 * 9600) / wpm;
-
-  // retune the rx pitch if needed
-  int cw_rx_pitch = field_int("PITCH");
-  if (cw_rx_pitch != decoder.signal_center.freq) {
-    cw_rx_bin_init(&decoder.signal_minus2, cw_rx_pitch - 150.0f, N_BINS, SAMPLING_FREQ);
-    cw_rx_bin_init(&decoder.signal_minus1, cw_rx_pitch - 75.0f, N_BINS, SAMPLING_FREQ);
-    cw_rx_bin_init(&decoder.signal_center, cw_rx_pitch + 0.0f, N_BINS, SAMPLING_FREQ);
-    cw_rx_bin_init(&decoder.signal_plus1, cw_rx_pitch + 75.0f, N_BINS, SAMPLING_FREQ);
-    cw_rx_bin_init(&decoder.signal_plus2, cw_rx_pitch + 150.0f, N_BINS, SAMPLING_FREQ);
-  }
-  // check if the wpm has changed
   if (wpm != decoder.wpm) {
     decoder.wpm = wpm;
     decoder.dot_len = (6 * SAMPLING_FREQ) / (5 * N_BINS * wpm);
   }
-  
-  // retune the tx decoder pitch if needed
+  if (wpm != tx_decoder.wpm) {
+    tx_decoder.wpm = wpm;
+  }
+
+  // retune RX pitch if needed
+  int cw_rx_pitch = field_int("PITCH");
+  if (cw_rx_pitch != decoder.signal_center.freq) {
+    cw_rx_bin_init(&decoder.signal_minus2, cw_rx_pitch - 150.0f, N_BINS, SAMPLING_FREQ);
+    cw_rx_bin_init(&decoder.signal_minus1, cw_rx_pitch - 75.0f,  N_BINS, SAMPLING_FREQ);
+    cw_rx_bin_init(&decoder.signal_center, cw_rx_pitch + 0.0f,   N_BINS, SAMPLING_FREQ);
+    cw_rx_bin_init(&decoder.signal_plus1,  cw_rx_pitch + 75.0f,  N_BINS, SAMPLING_FREQ);
+    cw_rx_bin_init(&decoder.signal_plus2,  cw_rx_pitch + 150.0f, N_BINS, SAMPLING_FREQ);
+  }
+
+  // retune TX decoder pitch if needed
   int cw_tx_pitch = get_pitch();
   if (cw_tx_pitch != tx_decoder.signal_center.freq) {
     cw_rx_bin_init(&tx_decoder.signal_center, cw_tx_pitch + 0.0f, N_BINS, SAMPLING_FREQ);
   }
-  // update tx decoder WPM
-  if (wpm != tx_decoder.wpm) {
-    tx_decoder.wpm = wpm;
-  }
-  
+
   // TX ON if bytes are available (from macro/keyboard) or key is pressed
   // or we are in the middle of symbol (dah/dit) transmission
-  millis_now = millis();
   if (!tx_is_on && ((cw_bytes_available > 0 && text_ready == 1) ||
         cw_key_state || (symbol_next && *symbol_next))) {
     tx_on(TX_SOFT);
-    cw_tx_until = get_cw_delay() + millis_now;
+    cw_tx_until = cw_delay_ms + millis_now;
     cw_mode = get_cw_input_method();
   } else if (tx_is_on && cw_tx_until < millis_now) {
-    // Flush any pending TX decode character
+    // flush any pending TX decode character
     cw_tx_emit_char();
-    // If we were in a TX session, write newline to end it
+    // if we were in a TX session, write newline to end it
     if (tx_session_active) {
       cw_write_console(STYLE_CW_TX, "\n");
       tx_session_active = false;

--- a/src/modem_cw.c
+++ b/src/modem_cw.c
@@ -233,6 +233,7 @@ static unsigned long millis_now = 0;
 static int cw_delay_ms = 300;
 static int cw_key_state = 0;
 static int cw_period;
+static int cw_pitch_hz = 700;   // cached TX pitch, refreshed in cw_poll()
 static struct vfo cw_tone;  // cw_env is replaced with data table
 static int keydown_count = 0;
 static int keyup_count = 0;
@@ -526,8 +527,8 @@ float cw_tx_get_sample() {
     // note current time to use with UI value of CW_DELAY to control break-in
     millis_now = millis();
     // set CW pitch if needed
-    if (cw_tone.freq_hz != get_pitch())
-      vfo_start( &cw_tone, get_pitch(), 0);
+    if (cw_tone.freq_hz != cw_pitch_hz)
+      vfo_start( &cw_tone, cw_pitch_hz, 0);
   }
   
   // check to see if input available from macro or keyboard
@@ -2160,9 +2161,10 @@ void cw_poll(int bytes_available, int tx_is_on) {
   }
 
   // retune TX decoder pitch if needed
-  int cw_tx_pitch = get_pitch();
-  if (cw_tx_pitch != tx_decoder.signal_center.freq) {
-    cw_rx_bin_init(&tx_decoder.signal_center, cw_tx_pitch + 0.0f, N_BINS, SAMPLING_FREQ);
+  // path (cw_tx_get_sample) does not call get_pitch() itself
+  cw_pitch_hz = get_pitch();
+  if (cw_pitch_hz != tx_decoder.signal_center.freq) {
+    cw_rx_bin_init(&tx_decoder.signal_center, cw_pitch_hz + 0.0f, N_BINS, SAMPLING_FREQ);
   }
 
   // TX ON if bytes are available (from macro/keyboard) or key is pressed

--- a/src/modems.c
+++ b/src/modems.c
@@ -403,7 +403,7 @@ void modem_rx(int mode, int32_t *samples, int count){
 	if (get_pitch() != last_pitch
 		&& (mode == MODE_CW || mode == MODE_CWR || mode == MODE_RTTY || mode == MODE_PSK31)) {
 		modem_set_pitch(get_pitch(),mode);
-		//last_pitch = get_pitch();
+		last_pitch = get_pitch();
 	}
 
 	s = samples;

--- a/src/modems.c
+++ b/src/modems.c
@@ -401,8 +401,10 @@ void modem_rx(int mode, int32_t *samples, int count){
 	char buff[10000];
 
 	if (get_pitch() != last_pitch
-		&& (mode == MODE_CW || mode == MODE_CWR || mode == MODE_RTTY || mode == MODE_PSK31))
+		&& (mode == MODE_CW || mode == MODE_CWR || mode == MODE_RTTY || mode == MODE_PSK31)) {
 		modem_set_pitch(get_pitch(),mode);
+		last_pitch = get_pitch();
+	}
 
 	s = samples;
 	switch(mode){

--- a/src/modems.c
+++ b/src/modems.c
@@ -403,7 +403,7 @@ void modem_rx(int mode, int32_t *samples, int count){
 	if (get_pitch() != last_pitch
 		&& (mode == MODE_CW || mode == MODE_CWR || mode == MODE_RTTY || mode == MODE_PSK31)) {
 		modem_set_pitch(get_pitch(),mode);
-		last_pitch = get_pitch();
+		//last_pitch = get_pitch();
 	}
 
 	s = samples;


### PR DESCRIPTION
an unreported bug - on sbitx startup, a first 'dit' from the paddle might not be detected.

The other changes are optimizations discovered working on zbitx, that save a lot of cpu cycles.